### PR TITLE
When the DisarmHTMLEntity child dies, log the exit status.

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/Message.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Message.pm
@@ -7017,6 +7017,8 @@ sub DisarmHTMLEntity {
   if ($PipeReturn) {
     # It went badly wrong!
     # Overwrite the output file to kill it, and return the error.
+    # Log the fact and the exit status.
+    MailScanner::Log::WarnLog("HTML disarming died, status = $PipeReturn");
     $outfh = new FileHandle;
     unless ($outfh->open(">$newname")) {
       MailScanner::Log::WarnLog('Could not wipe deadly HTML file %s',


### PR DESCRIPTION
This is the condition that produces "denial of service" messages. Log the exit status from the child that died for diagnosis.