### PR TITLE
Fix typo in Message.pm

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/Message.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Message.pm
@@ -5193,9 +5193,9 @@ sub DeliverUnmodifiedBody {
         #print STDERR "end\n";
         $global::MS->{mta}->AppendHeader($this, 'Subject:', $phishingtag, ' ');
         $subjectchanged = 1;
-      } elsif ($where =~ /start|1/ && !$global::MS->{mta}->TextStartsHeader($this, 'Subject:', $disarmtag)) {
+      } elsif ($where =~ /start|1/ && !$global::MS->{mta}->TextStartsHeader($this, 'Subject:', $phishingtag)) {
         #print STDERR "start\n";
-        $global::MS->{mta}->PrependHeader($this, 'Subject:', $disarmtag, ' ');
+        $global::MS->{mta}->PrependHeader($this, 'Subject:', $phishingtag, ' ');
         $subjectchanged = 1;
       }
     #}


### PR DESCRIPTION
Existing code appends $phishingtag if where is 'end' but prepends $disarmtag if where is 'start'. It should append/prepend $phishingtag in both cases