### PR TITLE
Fix enabling ramdisk on Debian

### DIFF
--- a/debian/install.sh
+++ b/debian/install.sh
@@ -425,7 +425,7 @@ else
 				echo "tmpfs ${DISK} tmpfs rw,size=${RAMDISKSIZE}M 0 0" >> /etc/fstab
 				echo "Enabling ramdisk sync ...";
 				if [ -f '/etc/MailScanner/defaults' ]; then
-					OLD="^#ramdisk_sync=1";
+					OLD="^ramdisk_sync=0";
 					NEW="ramdisk_sync=1";
 					sed -i "s/${OLD}/${NEW}/g" /etc/MailScanner/defaults
 				fi

--- a/rhel/install.sh
+++ b/rhel/install.sh
@@ -749,7 +749,7 @@ else
 				echo "tmpfs ${DISK} tmpfs rw,size=${RAMDISKSIZE}M 0 0" >> /etc/fstab
 				echo "Enabling ramdisk sync ...";
 				if [ -f '/etc/MailScanner/defaults' ]; then
-					OLD="^#ramdisk_sync=1";
+					OLD="^ramdisk_sync=0";
 					NEW="ramdisk_sync=1";
 					sed -i "s/${OLD}/${NEW}/g" /etc/MailScanner/defaults
 				fi

--- a/suse/install.sh
+++ b/suse/install.sh
@@ -481,7 +481,7 @@ else
 				echo "tmpfs ${DISK} tmpfs rw,size=${RAMDISKSIZE}M 0 0" >> /etc/fstab
 				echo "Enabling ramdisk sync ...";
 				if [ -f '/etc/MailScanner/defaults' ]; then
-					OLD="^#ramdisk_sync=1";
+					OLD="^ramdisk_sync=0";
 					NEW="ramdisk_sync=1";
 					sed -i "s/${OLD}/${NEW}/g" /etc/MailScanner/defaults
 				fi


### PR DESCRIPTION
/etc/MailScanner/default on Debian install states `ramdisk_sync=0` while install.sh search for `#ramdisk_sync=1` for sed substitution

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mailscanner/v5/24)
<!-- Reviewable:end -->
