### PR TITLE
grep [M]ailScanner needs to be quoted for the shell - grep '[M]ailSca…

### DIFF
--- a/common/usr/lib/MailScanner/init/ms-init
+++ b/common/usr/lib/MailScanner/init/ms-init
@@ -201,7 +201,7 @@ do_stop()
 	if [ "x$PID" = "x" ]; then
 		RETVAL=9
 	else
-		ps wwp $PID|grep -q [M]ailScanner: > /dev/null 2>&1
+		ps wwp $PID|grep -q '[M]ailScanner': > /dev/null 2>&1
 		RETVAL="$?"
 	fi
 
@@ -237,7 +237,11 @@ do_stop()
 		# MailScanner is not running
 		
 		# kill any rogue processes
-		kill $(ps axww | grep [M]ailScanner: | awk '{print $1}') > /dev/null 2>&1
+		kill $(ps axww | grep '[M]ailScanner': | awk '{print $1}') > /dev/null 2>&1
+		# wait until they're gone.
+		while (ps axww | grep -q '[M]ailScanner'); do
+		    sleep 1
+		done
 		
 		# these should not exist if the process is stopped, so they
 		# are removed if they do exist
@@ -309,7 +313,7 @@ case "$1" in
 			PID=$(head -n 1 $PIDFILE)
 			
 			# check to see if running and belongs to mailscanner
-			ps wwp $PID|grep -q [M]ailScanner: > /dev/null 2>&1
+			ps wwp $PID|grep -q '[M]ailScanner': > /dev/null 2>&1
 			
 			# get the return
 			RETVAL="$?"
@@ -320,7 +324,11 @@ case "$1" in
 					exit 0
 			else
 					[ "$VERBOSE" != no ] && logger -i -p mail.notice "Found a dead PID. Stopping all $NAME rogue processes ..."
-					kill -15 $(ps axww | grep [M]ailScanner: | awk '{print $1}') > /dev/null 2>&1
+					kill -15 $(ps axww | grep '[M]ailScanner': | awk '{print $1}') > /dev/null 2>&1
+					# wait until they're gone.
+					while (ps axww | grep -q '[M]ailScanner'); do
+					    sleep 1
+					done
 					rm -f $PIDFILE
 			fi
 	fi
@@ -365,7 +373,7 @@ case "$1" in
 		echo "$NAME started with process id $PID"
 	else
 		logger -i -p mail.notice "$NAME failed to start"
-		kill -15 $(ps axww | grep [M]ailScanner: | awk '{print $1}') > /dev/null 2>&1
+		kill -15 $(ps axww | grep '[M]ailScanner': | awk '{print $1}') > /dev/null 2>&1
 		exit 1
 	fi
 	
@@ -429,7 +437,7 @@ case "$1" in
 			PID=$(head -n 1 $PIDFILE)
 			
 			# check to see if running and belongs to mailscanner
-			ps wwp $PID|grep -q [M]ailScanner: > /dev/null 2>&1
+			ps wwp $PID|grep -q '[M]ailScanner': > /dev/null 2>&1
 			
 			# get the return
 			RETVAL="$?"
@@ -441,7 +449,11 @@ case "$1" in
 			else
 					[ "$VERBOSE" != no ] && logger -i -p mail.notice "Found a dead PID. Killing all $NAME rogue processes ..."
 					echo "$NAME had a dead PID. Any rogue processes were killed."
-					kill -15 $(ps axww | grep [M]ailScanner: | awk '{print $1}') > /dev/null 2>&1
+					kill -15 $(ps axww | grep '[M]ailScanner': | awk '{print $1}') > /dev/null 2>&1
+					# wait until they're gone.
+					while (ps axww | grep -q '[M]ailScanner'); do
+					    sleep 1
+					done
 					rm -f $PIDFILE
 			fi
 	fi
@@ -485,7 +497,7 @@ case "$1" in
 	else
 		logger -i -p mail.notice "$NAME failed to start"
 		echo "$NAME failed to start ... doh!"
-		kill $(ps axww | grep [M]ailScanner: | awk '{print $1}') > /dev/null 2>&1
+		kill $(ps axww | grep '[M]ailScanner': | awk '{print $1}') > /dev/null 2>&1
 		exit 1
 	fi
 	
@@ -524,7 +536,7 @@ case "$1" in
 	else
 		logger -i -p mail.notice "$NAME failed to start"
 		echo "$NAME failed to start ... doh!"
-		kill $(ps axww | grep [M]ailScanner: | awk '{print $1}') > /dev/null 2>&1
+		kill $(ps axww | grep '[M]ailScanner': | awk '{print $1}') > /dev/null 2>&1
 		exit 1
 	fi
 	
@@ -533,7 +545,11 @@ case "$1" in
   kill)
 	[ "$VERBOSE" != no ] && logger -i -p mail.notice "Killing $NAME "
 	echo "Killing $NAME and children ... mwa ha ha ha!"
-	kill -9 $(ps axww | grep [M]ailScanner: | awk '{print $1}') > /dev/null 2>&1
+	kill -9 $(ps axww | grep '[M]ailScanner': | awk '{print $1}') > /dev/null 2>&1
+	# wait until they're gone.
+	while (ps axww | grep -q '[M]ailScanner'); do
+	    sleep 1
+	done
 	
 	# remove subsys
 	if [ -f /var/lock/subsys/MailScanner ] ; then

--- a/common/usr/sbin/ms-check
+++ b/common/usr/sbin/ms-check
@@ -73,7 +73,7 @@ if [ -f $PIDFILE ] ; then
 	# get the PID
 	PID=$(head -n 1 $PIDFILE)
 	# check to see if running and belongs to mailscanner
-	ps wwp $PID|grep -iq [M]ailScanner > /dev/null 2>&1
+	ps wwp $PID|grep -iq '[M]ailScanner' > /dev/null 2>&1
 
 	# get the return
 	RETVAL="$?"
@@ -100,7 +100,11 @@ else
 	fi
 	
 	# kill any rogue processes
-	kill -15 $(ps axww | grep [M]ailScanner | awk '{print $1}') > /dev/null 2>&1
+	kill -15 $(ps axww | grep '[M]ailScanner' | awk '{print $1}') > /dev/null 2>&1
+	# wait until they're gone.
+	while (ps axww | grep -q '[M]ailScanner'); do
+	    sleep 1
+	done
 	
 
 	# log the start


### PR DESCRIPTION
…nner'

If it's not quoted, the shell replaces [M] with M and grep finds itself.

Added wait loop after some 'kill' commands to wait until processes are gone.

See http://lists.mailscanner.info/pipermail/mailscanner/2016-October/103988.html and http://lists.mailscanner.info/pipermail/mailscanner/2016-October/103980.html. Michael Young reports an issue with ms-check "fixed" by waiting. I don't think it can hurt to wait.
