### PR TITLE
Remove `—nodeps` option from package installer

### DIFF
--- a/debian/install.sh
+++ b/debian/install.sh
@@ -139,42 +139,12 @@ read -r -p "Install missing Perl modules via CPAN? [n/Y] : " response
 if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]; then
     # user wants to use CPAN for missing modules
 	CPANOPTION=1
-	
-	# rpm install will fail if the modules were not installed via RPM
-	# so i am setting the --nodeps flag here since the user elected to 
-	# use CPAN to remediate the modules
-	NODEPS='--nodeps';
-elif [ -z $response ]; then 
+elif [ -z $response ]; then
 	 # user wants to use CPAN for missing modules
 	CPANOPTION=1
-	
-	# rpm install will fail if the modules were not installed via RPM
-	# so i am setting the --nodeps flag here since the user elected to 
-	# use CPAN to remediate the modules
-	NODEPS='--nodeps';
 else
     # user does not want to use CPAN
     CPANOPTION=0
-fi
-
-# ask if the user wants to ignore dependencies. they are automatically ignored
-# if the user elected the CPAN option as explained above
-clear
-echo;
-echo "Do you want to ignore MailScanner dependencies?"; echo;
-echo "This will force install the MailScanner .deb package regardless of missing"; 
-echo "dependencies. It is highly recommended that you DO NOT do this unless you"; 
-echo "are debugging.";
-echo;
-echo "Recommended: N (no)"; echo;
-read -r -p "Ignore MailScanner dependencies (nodeps)? [y/N] : " response
-
-if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]; then
-	# user wants to ignore deps
-	NODEPS='--force'
-else
-	# requiring deps
-	NODEPS=
 fi
 
 # ask if the user wants to add a ramdisk
@@ -398,7 +368,7 @@ echo;
 echo "Installing the MailScanner .deb package ... ";
 
 # install the mailscanner package
-dpkg -i $CONFFILES $NODEPS $THISCURRPMDIR/MailScanner-*-noarch.deb
+dpkg -i $CONFFILES $THISCURRPMDIR/MailScanner-*-noarch.deb
 
 if [ $? != 0 ]; then
 	echo;

--- a/rhel/install.sh
+++ b/rhel/install.sh
@@ -238,19 +238,9 @@ read -r -p "Install missing Perl modules via CPAN? [n/Y] : " response
 if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]; then
     # user wants to use CPAN for missing modules
 	CPANOPTION=1
-	
-	# rpm install will fail if the modules were not installed via RPM
-	# so i am setting the --nodeps flag here since the user elected to 
-	# use CPAN to remediate the modules
-	NODEPS='--nodeps';
-elif [ -z $response ]; then 
+elif [ -z $response ]; then
 	 # user wants to use CPAN for missing modules
 	CPANOPTION=1
-	
-	# rpm install will fail if the modules were not installed via RPM
-	# so i am setting the --nodeps flag here since the user elected to 
-	# use CPAN to remediate the modules
-	NODEPS='--nodeps';
 else
     # user does not want to use CPAN
     CPANOPTION=0
@@ -281,28 +271,6 @@ if [ $RHEL == 7 ]; then
 	else
 		# user does not want to use RPM
 		DFOPTION=0
-	fi
-fi
-
-# ask if the user wants to ignore dependencies. they are automatically ignored
-# if the user elected the CPAN option as explained above
-if [ $CPANOPTION != 1 ]; then
-	clear
-	echo;
-	echo "Do you want to ignore MailScanner dependencies?"; echo;
-	echo "This will force install the MailScanner RPM package regardless of missing"; 
-	echo "dependencies. It is highly recommended that you DO NOT do this unless you"; 
-	echo "are debugging.";
-	echo;
-	echo "Recommended: N (no)"; echo;
-	read -r -p "Ignore MailScanner dependencies (nodeps)? [y/N] : " response
-
-	if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]; then
-		# user wants to ignore deps
-		NODEPS='--nodeps --force'
-	else
-		# requiring deps
-		NODEPS=
 	fi
 fi
 
@@ -721,7 +689,7 @@ echo;
 echo "Installing the MailScanner RPM ... ";
 
 # install the mailscanner rpm
-$RPM -Uvh --force $NODEPS MailScanner*noarch.rpm
+$RPM -Uvh --force MailScanner*noarch.rpm
 
 if [ $? != 0 ]; then
 	echo;

--- a/suse/install.sh
+++ b/suse/install.sh
@@ -31,7 +31,7 @@ if [ $(whoami) != "root" ]; then
 	exit 192
 fi
 
-# bail if yum is not installed
+# bail if zipper is not installed
 if [ ! -x '/usr/bin/zypper' ]; then
 	clear
 	echo;
@@ -144,19 +144,9 @@ read -r -p "Install missing Perl modules via CPAN? [n/Y] : " response
 if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]; then
     # user wants to use CPAN for missing modules
 	CPANOPTION=1
-	
-	# rpm install will fail if the modules were not installed via RPM
-	# so i am setting the --nodeps flag here since the user elected to 
-	# use CPAN to remediate the modules
-	NODEPS='--nodeps';
-elif [ -z $response ]; then 
+elif [ -z $response ]; then
 	 # user wants to use CPAN for missing modules
 	CPANOPTION=1
-	
-	# rpm install will fail if the modules were not installed via RPM
-	# so i am setting the --nodeps flag here since the user elected to 
-	# use CPAN to remediate the modules
-	NODEPS='--nodeps';
 else
     # user does not want to use CPAN
     CPANOPTION=0
@@ -174,28 +164,6 @@ else
 	# don't install if not using CPAN
 	CAV=0
 	SA=0
-fi
-
-# ask if the user wants to ignore dependencies. they are automatically ignored
-# if the user elected the CPAN option as explained above
-if [ $CPANOPTION != 1 ]; then
-	clear
-	echo;
-	echo "Do you want to ignore MailScanner dependencies?"; echo;
-	echo "This will force install the MailScanner RPM package regardless of missing"; 
-	echo "dependencies. It is highly recommended that you DO NOT do this unless you"; 
-	echo "are debugging.";
-	echo;
-	echo "Recommended: N (no)"; echo;
-	read -r -p "Ignore MailScanner dependencies (nodeps)? [y/N] : " response
-
-	if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]; then
-		# user wants to ignore deps
-		NODEPS='--nodeps'
-	else
-		# requiring deps
-		NODEPS=
-	fi
 fi
 
 # ask if the user wants to add a ramdisk
@@ -453,7 +421,7 @@ echo "Installing the MailScanner RPM ... ";
 # using --force option to reinstall the rpm if the same version is
 # already installed. this will not overwrite configuration files
 # as they are protected in the rpm spec file
-$RPM -Uvh $NODEPS MailScanner*noarch.rpm
+$RPM -Uvh MailScanner*noarch.rpm
 
 if [ $? != 0 ]; then
 	echo;


### PR DESCRIPTION
Past commits (debian f1d79afd7c076356b3dd958fb234cd8393dbcce7, rhel 5d03e03d93ce50094f275aafa0f342b7fe739038, suse 40d997b9fdd11a6c0f5b0fdd9326ea1a1e3a29f2 ) removed perl libs requirement from install package: this patch removed option to ignore MailScanner dependencies from install script

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mailscanner/v5/29)
<!-- Reviewable:end -->
