### PR TITLE
Fix for https://github.com/MailScanner/v5/issues/43.

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/Message.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Message.pm
@@ -4597,7 +4597,11 @@ sub SignWarningMessage {
     $warning = $this->ReadVirusWarning('inlinehtmlwarning');
     #$warning = quotemeta $warning; # Must leave HTML tags alone!
     foreach $line (@body) {
-      $line =~ s/\<html\>/$&$warning/i;
+      # html tags can have extra attributes.  In a case where the <html> tag
+      # has attributes and is closed on a subsequent line, the warning will
+      # actually be in the tag, but it's malformed in any case because it
+      # precedes any <head> and <body> tags and clients seem to render it OK.
+      $line =~ s/\<html( [^>]*)?(\>|$)/$&$warning/i;
       $io->print($line);
     }
   } else {


### PR DESCRIPTION
This fix is imperfect in the case where the <html ... > tag is split across lines, but it seems to produce an acceptable result, and it fixes #43 in any case.