### PR TITLE
Fix configuration chaining for spamassassin rules actions

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/Config.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Config.pm
@@ -319,6 +319,7 @@ sub Value {
       }
     }
     # Return the results if there were any, else the defaults
+    return join(",", @results) if @results and $name eq 'saactions';
     return join(" ", @results) if @results;
     return $Defaults{$name};
   }


### PR DESCRIPTION
I found a subtle bug while playing with SpamAssassin Rule Actions, for which I found a fix.

From the docs:

*SpamAssassin Rule Actions* (Ruleset Type: 	All Match)

[...] The setting consists of a comma-separated list of ` SA_RULENAME=>action,action,...` pairs, where `SA_RULENAME` is the name of any SpamAssassin rule, and `action` is the name of any of the actions [...] or the word "not-" preceding any  of the action names.

The problem is in `Config.pm`:
```perl
sub Value {
    # ------ cut -----
    # It's an all-matches rule
    foreach $rule (@{$rulelist}) {
        # ------ cut -----
        $result = AllMatchesValue($direction, $iporaddr, $regexp2, $valuea, $name, $msg, $tooverride);
        # ------ cut -----
        push @results, $result;
    }
    # ------ cut -----

    # Return the results if there were any, else the defaults
    return join(" ", @results) if @results;
    return $Defaults{$name};
  }
}
```
The copied part is about multi-rule parsing, where you can see, that returned values are joined by space, not by commas. Then the function for spamassassin rules action fails miserably, as it expects actions called like `RULE=>action,RULE2=>action2`, but it finds `RULE=>action RULE2=>action2`.

My poor-programmers fix is just adding an exception for `saactions`, but other multi-rule options may be affected and I don't know how to dig into other case. 
