### PR TITLE
systemd enhancements

### DIFF
--- a/Build.debian
+++ b/Build.debian
@@ -96,6 +96,7 @@ chmod +x $WORK/DEBIAN/postrm
 chmod +x $WORK/usr/lib/MailScanner/wrapper/*-autoupdate
 chmod +x $WORK/usr/lib/MailScanner/wrapper/*-wrapper
 chmod +x $WORK/usr/lib/MailScanner/init/*
+chmod +x $WORK/usr/lib/MailScanner/systemd/*
 chmod +x $WORK/etc/cron.daily/*
 chmod +x $WORK/etc/cron.hourly/*
 

--- a/Build.rhel
+++ b/Build.rhel
@@ -96,6 +96,7 @@ cp -fr $DEVBASEDIR/rhel/etc/*		$WORK/etc/
 
 # usr
 cp -fr $DEVBASEDIR/common/usr/* 	$WORK/usr/
+cp -fr $DEVBASEDIR/rhel/usr/* 	    $WORK/usr/
 
 # Insert the version number we are building
 perl -pi -e 's/VersionNumberHere/'$MSVERSION'/;' $WORK/etc/MailScanner/MailScanner.conf

--- a/common/usr/lib/MailScanner/systemd/ms-systemd
+++ b/common/usr/lib/MailScanner/systemd/ms-systemd
@@ -1,0 +1,19 @@
+[Unit]
+Description=LSB: MailScanner daemon
+Documentation=man:systemd-sysv-generator(8)
+SourcePath=/usr/lib/MailScanner/init/ms-init
+After=network-online.target remote-fs.target rsyslog.service
+
+[Service]
+Type=forking
+Restart=no
+TimeoutSec=1min
+IgnoreSIGPIPE=no
+KillMode=process
+GuessMainPID=no
+RemainAfterExit=yes
+ExecStart=/usr/lib/MailScanner/init/ms-init start
+ExecStop=/usr/lib/MailScanner/init/ms-init stop
+
+[Install]
+WantedBy=multi-user.target

--- a/debian/DEBIAN/postinst
+++ b/debian/DEBIAN/postinst
@@ -142,8 +142,16 @@ if [ -f '/etc/init.d/MailScanner' ]; then
 	rm -f /etc/init.d/MailScanner
 fi
 
+# remove old systemd file if present
+if [ -f '/lib/systemd/system/mailscanner.service' ]; then
+    rm -f /lib/systemd/system/mailscanner.service
+fi
+
+# Check for systemd
+if [ -d '/usr/lib/systemd' ]; then
+    cp /usr/lib/MailScanner/systemd/ms-systemd /lib/systemd/system/mailscanner.service
 # add symlink to init script
-if [ ! -L '/etc/init.d/mailscanner' ]; then
+elif [ ! -L '/etc/init.d/mailscanner' ]; then
 	ln -s /usr/lib/MailScanner/init/ms-init /etc/init.d/mailscanner
 fi
 
@@ -266,7 +274,11 @@ if [ -f '/etc/postfix/master.cf' ]; then
 	sed -i "s/pickup    unix/pickup    fifo/g" /etc/postfix/master.cf
 	sed -i "s/qmgr      unix/qmgr      fifo/g" /etc/postfix/master.cf
 fi
-		
-update-rc.d mailscanner defaults 80 80
+
+if [ -d '/usr/lib/systemd' ]; then
+    systemctl enable mailscanner.service
+else
+    update-rc.d mailscanner defaults 80 80
+fi
 
 exit 0

--- a/debian/DEBIAN/postrm
+++ b/debian/DEBIAN/postrm
@@ -6,6 +6,11 @@ set -e
 # unregister the old startup script
 update-rc.d -f mailscanner remove
 
+if [ -d '/usr/lib/systemd' && -f '/lib/systemd/system/mailscanner.service' ]; then
+    systemctl disable mailscanner.service
+    rm -f /lib/systemd/system/mailscanner.service
+fi
+
 if [ -L '/etc/init.d/mailscanner' ]; then
 	rm -f /etc/init.d/mailscanner
 fi

--- a/rhel/mailscanner.spec
+++ b/rhel/mailscanner.spec
@@ -16,7 +16,7 @@ Vendor:      MailScanner Community
 Packager:    Jerry Benton <mailscanner@mailborder.com>
 URL:         http://www.mailscanner.info
 Requires:     perl >= 5.005
-Provides:	  perl(MailScanner), perl(MailScanner::Antiword), perl(MailScanner::BinHex), perl(MailScanner::Config), perl(MailScanner::ConfigSQL), perl(MailScanner::CustomConfig), perl(MailScanner::FileInto), perl(MailScanner::GenericSpam), perl(MailScanner::LinksDump), perl(MailScanner::Lock), perl(MailScanner::Log), perl(MailScanner::Mail), perl(MailScanner::MCP), perl(MailScanner::MCPMessage), perl(MailScanner::Message), perl(MailScanner::MessageBatch), perl(MailScanner::Quarantine), perl(MailScanner::Queue), perl(MailScanner::RBLs), perl(MailScanner::MCPMessage), perl(MailScanner::Message), perl(MailScanner::MCP), perl(MailScanner::SA), perl(MailScanner::Sendmail), perl(MailScanner::SMDiskStore), perl(MailScanner::SweepContent), perl(MailScanner::SweepOther), perl(MailScanner::SweepViruses), perl(MailScanner::TNEF), perl(MailScanner::Unzip), perl(MailScanner::WorkArea), perl(MIME::Parser::MailScanner)
+Provides:     perl(MailScanner), perl(MailScanner::Antiword), perl(MailScanner::BinHex), perl(MailScanner::Config), perl(MailScanner::ConfigSQL), perl(MailScanner::CustomConfig), perl(MailScanner::FileInto), perl(MailScanner::GenericSpam), perl(MailScanner::LinksDump), perl(MailScanner::Lock), perl(MailScanner::Log), perl(MailScanner::Mail), perl(MailScanner::MCP), perl(MailScanner::MCPMessage), perl(MailScanner::Message), perl(MailScanner::MessageBatch), perl(MailScanner::Quarantine), perl(MailScanner::Queue), perl(MailScanner::RBLs), perl(MailScanner::MCPMessage), perl(MailScanner::Message), perl(MailScanner::MCP), perl(MailScanner::SA), perl(MailScanner::Sendmail), perl(MailScanner::SMDiskStore), perl(MailScanner::SweepContent), perl(MailScanner::SweepOther), perl(MailScanner::SweepViruses), perl(MailScanner::TNEF), perl(MailScanner::Unzip), perl(MailScanner::WorkArea), perl(MIME::Parser::MailScanner)
 Source:      %{name}-%{version}.tgz
 BuildRoot:   %{_tmppath}/%{name}-root
 BuildArchitectures: noarch
@@ -26,18 +26,18 @@ Obsoletes: mailscanner
 
 %description
 MailScanner is a freely distributable email gateway virus scanner with
-malware, phishing, and spam detection. It supports Postfix, sendmail, 
-ZMailer, Qmail or Exim mail transport agents and numerous open source 
-and commercial virus scanning engines for virus scanning.  It will also 
-selectively filter the content of email messages to protect users from 
-offensive content such as pornographic spam. It also has features which 
+malware, phishing, and spam detection. It supports Postfix, sendmail,
+ZMailer, Qmail or Exim mail transport agents and numerous open source
+and commercial virus scanning engines for virus scanning.  It will also
+selectively filter the content of email messages to protect users from
+offensive content such as pornographic spam. It also has features which
 protect it against Denial Of Service attacks.
 
 After installation, you must install one of the supported open source or
 commercial antivirus packages if not installed using the MailScanner
 installation script.
 
-This has been tested on Red Hat Linux, but should work on other RPM 
+This has been tested on Red Hat Linux, but should work on other RPM
 based Linux distributions.
 
 %prep
@@ -53,7 +53,7 @@ mkdir -p ${RPM_BUILD_ROOT}/etc/MailScanner/{conf.d,rules,mcp}
 mkdir -p ${RPM_BUILD_ROOT}/etc/{cron.hourly,cron.daily}
 mkdir -p ${RPM_BUILD_ROOT}/usr/share/MailScanner/reports/{hu,de,se,ca,cy+en,pt_br,fr,es,en,cz,it,dk,nl,ro,sk}
 mkdir -p ${RPM_BUILD_ROOT}/usr/share/MailScanner/perl/{MailScanner,custom}
-mkdir -p ${RPM_BUILD_ROOT}/usr/{lib/MailScanner/wrapper,lib/MailScanner/init}
+mkdir -p ${RPM_BUILD_ROOT}/usr/{lib/MailScanner/wrapper,lib/MailScanner/init,lib/MailScanner/systemd}
 mkdir -p ${RPM_BUILD_ROOT}/var/spool/MailScanner/{archive,incoming,quarantine}
 
 ### etc
@@ -102,23 +102,23 @@ EOF
 
 ### usr/sbin
 
-install usr/sbin/MailScanner        				${RPM_BUILD_ROOT}/usr/sbin/MailScanner
-install usr/sbin/ms-check      						${RPM_BUILD_ROOT}/usr/sbin/ms-check
-install usr/sbin/ms-clean-quarantine				${RPM_BUILD_ROOT}/usr/sbin/ms-clean-quarantine
-install usr/sbin/ms-create-locks 					${RPM_BUILD_ROOT}/usr/sbin/ms-create-locks
-install usr/sbin/ms-cron            				${RPM_BUILD_ROOT}/usr/sbin/ms-cron
-install usr/sbin/ms-d2mbox             				${RPM_BUILD_ROOT}/usr/sbin/ms-d2mbox
-install usr/sbin/ms-df2mbox            				${RPM_BUILD_ROOT}/usr/sbin/ms-df2mbox
-install usr/sbin/ms-msg-alert 						${RPM_BUILD_ROOT}/usr/sbin/ms-msg-alert
-install usr/sbin/ms-peek         					${RPM_BUILD_ROOT}/usr/sbin/ms-peek
-install usr/sbin/ms-perl-check     					${RPM_BUILD_ROOT}/usr/sbin/ms-perl-check
-install usr/sbin/ms-sa-cache     					${RPM_BUILD_ROOT}/usr/sbin/ms-sa-cache
-install usr/sbin/ms-update-bad-emails 				${RPM_BUILD_ROOT}/usr/sbin/ms-update-bad-emails
-install usr/sbin/ms-update-bad-sites 				${RPM_BUILD_ROOT}/usr/sbin/ms-update-bad-sites
-install usr/sbin/ms-update-sa 						${RPM_BUILD_ROOT}/usr/sbin/ms-update-sa
-install usr/sbin/ms-update-safe-sites 				${RPM_BUILD_ROOT}/usr/sbin/ms-update-safe-sites
-install usr/sbin/ms-update-vs 						${RPM_BUILD_ROOT}/usr/sbin/ms-update-vs
-install usr/sbin/ms-upgrade-conf 					${RPM_BUILD_ROOT}/usr/sbin/ms-upgrade-conf
+install usr/sbin/MailScanner                        ${RPM_BUILD_ROOT}/usr/sbin/MailScanner
+install usr/sbin/ms-check                           ${RPM_BUILD_ROOT}/usr/sbin/ms-check
+install usr/sbin/ms-clean-quarantine                ${RPM_BUILD_ROOT}/usr/sbin/ms-clean-quarantine
+install usr/sbin/ms-create-locks                    ${RPM_BUILD_ROOT}/usr/sbin/ms-create-locks
+install usr/sbin/ms-cron                            ${RPM_BUILD_ROOT}/usr/sbin/ms-cron
+install usr/sbin/ms-d2mbox                          ${RPM_BUILD_ROOT}/usr/sbin/ms-d2mbox
+install usr/sbin/ms-df2mbox                         ${RPM_BUILD_ROOT}/usr/sbin/ms-df2mbox
+install usr/sbin/ms-msg-alert                       ${RPM_BUILD_ROOT}/usr/sbin/ms-msg-alert
+install usr/sbin/ms-peek                            ${RPM_BUILD_ROOT}/usr/sbin/ms-peek
+install usr/sbin/ms-perl-check                      ${RPM_BUILD_ROOT}/usr/sbin/ms-perl-check
+install usr/sbin/ms-sa-cache                        ${RPM_BUILD_ROOT}/usr/sbin/ms-sa-cache
+install usr/sbin/ms-update-bad-emails               ${RPM_BUILD_ROOT}/usr/sbin/ms-update-bad-emails
+install usr/sbin/ms-update-bad-sites                ${RPM_BUILD_ROOT}/usr/sbin/ms-update-bad-sites
+install usr/sbin/ms-update-sa                       ${RPM_BUILD_ROOT}/usr/sbin/ms-update-sa
+install usr/sbin/ms-update-safe-sites               ${RPM_BUILD_ROOT}/usr/sbin/ms-update-safe-sites
+install usr/sbin/ms-update-vs                       ${RPM_BUILD_ROOT}/usr/sbin/ms-update-vs
+install usr/sbin/ms-upgrade-conf                    ${RPM_BUILD_ROOT}/usr/sbin/ms-upgrade-conf
 
 
 ### usr/share/MailScanner
@@ -220,6 +220,17 @@ EOF
 ### usr/lib/MailScanner
 
 install usr/lib/MailScanner/init/ms-init ${RPM_BUILD_ROOT}/usr/lib/MailScanner/init/
+install usr/lib/MailScanner/init/ms-sendmail-init ${RPM_BUILD_ROOT}/usr/lib/MailScanner/init/
+
+while read f 
+do
+  install usr/lib/MailScanner/systemd/$f ${RPM_BUILD_ROOT}/usr/lib/MailScanner/systemd
+done << EOF
+ms-systemd
+ms-sendmail
+ms-sendmail-in
+ms-sendmail-out
+EOF
 
 while read f 
 do
@@ -251,66 +262,96 @@ SAVEDIR="$HOME/ms_upgrade/saved.$$";
 
 # remove old symlink if present
 if [ -L '/etc/init.d/mailscanner' ]; then
-	chkconfig --del mailscanner >/dev/null 2>&1
-	rm -f /etc/init.d/mailscanner
+    chkconfig --del mailscanner >/dev/null 2>&1
+    rm -f /etc/init.d/mailscanner
 fi
 
 # remove old file if present
 if [ -f '/etc/init.d/mailscanner' ]; then
-	chkconfig --del mailscanner >/dev/null 2>&1
-	rm -f /etc/init.d/mailscanner
+    chkconfig --del mailscanner >/dev/null 2>&1
+    rm -f /etc/init.d/mailscanner
 fi
 
 # remove old symlink if present
 if [ -L '/etc/init.d/MailScanner' ]; then
-	chkconfig --del MailScanner >/dev/null 2>&1
-	rm -f /etc/init.d/MailScanner
+    chkconfig --del MailScanner >/dev/null 2>&1
+    rm -f /etc/init.d/MailScanner
 fi
 
 # remove old file if present
 if [ -f '/etc/init.d/MailScanner' ]; then
-	chkconfig --del MailScanner >/dev/null 2>&1
-	rm -f /etc/init.d/MailScanner
+   chkconfig --del MailScanner >/dev/null 2>&1
+   rm -f /etc/init.d/MailScanner
+fi
+
+# remove old file if present
+if [ -f '/usr/lib/systemd/system/mailscanner' ]; then
+   systemctl disable mailscanner >/dev/null 2>&1
+   rm -f /usr/lib/systemd/system/mailscanner
+fi
+
+# remove old file if present
+if [ -f '/etc/init.d/ms-sendmail' ]; then
+   chkconfig --del ms-sendmail >/dev/null 2>&10
+   rm -f /etc/init.d/ms-sendmail
+fi
+
+# remove old file if present
+if [ -f '/usr/lib/systemd/system/ms-sendmail' ]; then
+   systemctl disable ms-sendmail >/dev/null 2>&1
+   rm -f /usr/lib/systemd/system/ms-sendmail
+fi
+
+# remove old file if present
+if [ -f '/usr/lib/systemd/system/ms-sendmail-in' ]; then
+   systemctl disable ms-sendmail-in >/dev/null 2>&1
+   rm -f /usr/lib/systemd/system/ms-sendmail-in
+fi
+
+# remove old file if present
+if [ -f '/usr/lib/systemd/system/ms-sendmail-out' ]; then
+   systemctl disable ms-sendmail-out >/dev/null 2>&1
+   rm -f /usr/lib/systemd/system/ms-sendmail-out
 fi
 
 if [ -d '/usr/lib/MailScanner/MailScanner/CustomFunctions' ]; then
-	mkdir -p ${SAVEDIR}/usr/lib/MailScanner/MailScanner/CustomFunctions
-	cp -f /usr/lib/MailScanner/MailScanner/CustomFunctions/* ${SAVEDIR}/usr/lib/MailScanner/MailScanner/CustomFunctions
-	if [ -d '/usr/lib/MailScanner/MailScanner' ]; then
-		rm -rf /usr/lib/MailScanner/MailScanner
-	fi
+    mkdir -p ${SAVEDIR}/usr/lib/MailScanner/MailScanner/CustomFunctions
+    cp -f /usr/lib/MailScanner/MailScanner/CustomFunctions/* ${SAVEDIR}/usr/lib/MailScanner/MailScanner/CustomFunctions
+    if [ -d '/usr/lib/MailScanner/MailScanner' ]; then
+        rm -rf /usr/lib/MailScanner/MailScanner
+    fi
 fi
 
 if [ -d '/etc/MailScanner/CustomFunctions' ]; then
-	mkdir -p ${SAVEDIR}/etc/MailScanner/CustomFunctions
-	cp -f /etc/MailScanner/CustomFunctions/* ${SAVEDIR}/etc/MailScanner/CustomFunctions
-	rm -rf /etc/MailScanner/CustomFunctions
+    mkdir -p ${SAVEDIR}/etc/MailScanner/CustomFunctions
+    cp -f /etc/MailScanner/CustomFunctions/* ${SAVEDIR}/etc/MailScanner/CustomFunctions
+    rm -rf /etc/MailScanner/CustomFunctions
 fi
 
 if [ -L '/etc/MailScanner/CustomFunctions' ]; then
-	rm -f /etc/MailScanner/CustomFunctions
+    rm -f /etc/MailScanner/CustomFunctions
 fi
 
 if [ -f '/etc/MailScanner/CustomConfig.pm' ]; then
-	mkdir -p ${SAVEDIR}/etc/MailScanner
-	cp -f /etc/MailScanner/CustomConfig.pm ${SAVEDIR}/etc/MailScanner/
-	rm -f /etc/MailScanner/CustomConfig.pm
+    mkdir -p ${SAVEDIR}/etc/MailScanner
+    cp -f /etc/MailScanner/CustomConfig.pm ${SAVEDIR}/etc/MailScanner/
+    rm -f /etc/MailScanner/CustomConfig.pm
 fi
 
 if [ -d '/etc/MailScanner/reports' ]; then
-	mkdir -p ${SAVEDIR}/etc/MailScanner/reports
-	cp -rf /etc/MailScanner/reports/* ${SAVEDIR}/etc/MailScanner/reports
-	rm -rf /etc/MailScanner/reports
+    mkdir -p ${SAVEDIR}/etc/MailScanner/reports
+    cp -rf /etc/MailScanner/reports/* ${SAVEDIR}/etc/MailScanner/reports
+    rm -rf /etc/MailScanner/reports
 fi
 
 if [ -d '/usr/share/MailScanner/MailScanner' ]; then
-	rm -rf /usr/share/MailScanner/MailScanner
+    rm -rf /usr/share/MailScanner/MailScanner
 fi
 
 if [ -f '/etc/MailScanner/MailScanner.conf' ]; then
-	mkdir -p ${SAVEDIR}/etc/MailScanner
-	cp -f /etc/MailScanner/MailScanner.conf ${SAVEDIR}/etc/MailScanner/MailScanner.conf.original
-fi	
+    mkdir -p ${SAVEDIR}/etc/MailScanner
+    cp -f /etc/MailScanner/MailScanner.conf ${SAVEDIR}/etc/MailScanner/MailScanner.conf.original
+fi
 
 exit 0
  
@@ -323,179 +364,201 @@ SAVEDIR="$HOME/ms_upgrade/saved.$$";
 CAVOLD='^#AllowSupplementaryGroups.*';
 CAVNEW='AllowSupplementaryGroups yes';
 if [ -f '/etc/clamd.conf' ]; then
-	sed -i "s/${CAVOLD}/${CAVNEW}/g" /etc/clamd.conf
+    sed -i "s/${CAVOLD}/${CAVNEW}/g" /etc/clamd.conf
 fi
 
 # group for users to run under
 if ! getent group mtagroup >/dev/null 2>&1; then
-	groupadd -f mtagroup >/dev/null 2>&1
+    groupadd -f mtagroup >/dev/null 2>&1
 fi
 
 # check for common users and add to the mtagroup
 if id -u clam >/dev/null 2>&1; then
-	usermod -a -G mtagroup clam >/dev/null 2>&1
+    usermod -a -G mtagroup clam >/dev/null 2>&1
 fi
 
 if id -u clamav >/dev/null 2>&1; then
-	usermod -a -G mtagroup clamav >/dev/null 2>&1
+    usermod -a -G mtagroup clamav >/dev/null 2>&1
 fi
 
 if id -u clamscan >/dev/null 2>&1; then
-	usermod -a -G mtagroup clamscan >/dev/null 2>&1
+    usermod -a -G mtagroup clamscan >/dev/null 2>&1
 fi
 
 if id -u vscan >/dev/null 2>&1; then
-	usermod -a -G mtagroup vscan >/dev/null 2>&1
+    usermod -a -G mtagroup vscan >/dev/null 2>&1
 fi
 
 if id -u sophosav >/dev/null 2>&1; then
-	usermod -a -G mtagroup sophosav >/dev/null 2>&1
+    usermod -a -G mtagroup sophosav >/dev/null 2>&1
 fi
 
 if id -u postfix >/dev/null 2>&1; then
-	usermod -a -G mtagroup postfix >/dev/null 2>&1
+    usermod -a -G mtagroup postfix >/dev/null 2>&1
 fi
 
 if id -u mail >/dev/null 2>&1; then
-	usermod -a -G mtagroup mail >/dev/null 2>&1
+    usermod -a -G mtagroup mail >/dev/null 2>&1
 fi
 
 if id -u avast >/dev/null 2>&1; then
-	usermod -a -G mtagroup avast >/dev/null 2>&1
+    usermod -a -G mtagroup avast >/dev/null 2>&1
 fi
 
 if [ ! -d '/var/spool/MailScanner/archive' ]; then
-	mkdir -p /var/spool/MailScanner/archive
+    mkdir -p /var/spool/MailScanner/archive
 fi
 
 if [ ! -d '/var/spool/MailScanner/incoming' ]; then
-	mkdir -p /var/spool/MailScanner/incoming
+    mkdir -p /var/spool/MailScanner/incoming
 fi
 
 if [ ! -d '/var/spool/MailScanner/quarantine' ]; then
-	mkdir -p /var/spool/MailScanner/quarantine
+    mkdir -p /var/spool/MailScanner/quarantine
 fi
 
 # remove old link if present
 if [ -L '/etc/mail/spamassassin/mailscanner.cf' ]; then
-	rm -f /etc/mail/spamassassin/mailscanner.cf
+    rm -f /etc/mail/spamassassin/mailscanner.cf
 fi
 
 if [ -L '/etc/mail/spamassassin/MailScanner.cf' ]; then
-	rm -f /etc/mail/spamassassin/MailScanner.cf
+    rm -f /etc/mail/spamassassin/MailScanner.cf
 fi
 
 if [ -f '/etc/MailScanner/spam.assassin.prefs.conf' ]; then
-	mv -f /etc/MailScanner/spam.assassin.prefs.conf /etc/MailScanner/spamassassin.conf
+    mv -f /etc/MailScanner/spam.assassin.prefs.conf /etc/MailScanner/spamassassin.conf
 fi
 
 # create symlink for spamasassin
 if [ -d '/etc/mail/spamassassin' -a ! -L '/etc/mail/spamassassin/MailScanner.cf' -a -f '/etc/MailScanner/spamassassin.conf' -a ! -f '/etc/mail/spamassassin/MailScanner.cf' ]; then
-	ln -s /etc/MailScanner/spamassassin.conf /etc/mail/spamassassin/MailScanner.cf 
+    ln -s /etc/MailScanner/spamassassin.conf /etc/mail/spamassassin/MailScanner.cf 
 fi
 
 # upgrade the old config
 if [ -f /etc/MailScanner/MailScanner.conf.original -a -f /etc/MailScanner/MailScanner.conf ]; then
-	cp -f /etc/MailScanner/MailScanner.conf /etc/MailScanner/MailScanner.conf.dist
-	ms-upgrade-conf /etc/MailScanner/MailScanner.conf.original /etc/MailScanner/MailScanner.conf.dist > /etc/MailScanner/MailScanner.conf
-	mkdir -p ${SAVEDIR}/etc/MailScanner
-	mv -f /etc/MailScanner/MailScanner.conf.* ${SAVEDIR}/etc/MailScanner > /dev/null 2>&1
-	cp -f /etc/MailScanner/MailScanner.conf ${SAVEDIR}/etc/MailScanner/MailScanner.new > /dev/null 2>&1
+    cp -f /etc/MailScanner/MailScanner.conf /etc/MailScanner/MailScanner.conf.dist
+    ms-upgrade-conf /etc/MailScanner/MailScanner.conf.original /etc/MailScanner/MailScanner.conf.dist > /etc/MailScanner/MailScanner.conf
+    mkdir -p ${SAVEDIR}/etc/MailScanner
+    mv -f /etc/MailScanner/MailScanner.conf.* ${SAVEDIR}/etc/MailScanner > /dev/null 2>&1
+    cp -f /etc/MailScanner/MailScanner.conf ${SAVEDIR}/etc/MailScanner/MailScanner.new > /dev/null 2>&1
 fi
 
 # update web bug link
 OLD="^Web Bug Replacement.*";
 NEW="Web Bug Replacement = https\:\/\/s3\.amazonaws\.com\/msv5\/images\/spacer\.gif";
 if [ -f '/etc/MailScanner/MailScanner.conf' ]; then
-	sed -i "s/${OLD}/${NEW}/g" /etc/MailScanner/MailScanner.conf
+    sed -i "s/${OLD}/${NEW}/g" /etc/MailScanner/MailScanner.conf
 fi
 
 # fix reports directory
 OLDTHING='\/etc\/MailScanner\/reports';
 NEWTHING='\/usr\/share\/MailScanner\/reports';
 if [ -f '/etc/MailScanner/MailScanner.conf' ]; then
-	sed -i "s/${OLDTHING}/${NEWTHING}/g" /etc/MailScanner/MailScanner.conf
+    sed -i "s/${OLDTHING}/${NEWTHING}/g" /etc/MailScanner/MailScanner.conf
 fi
 
 # fix custom functions directory
 OLDTHING='^Custom Functions Dir.*';
 NEWTHING='Custom Functions Dir = \/usr\/share\/MailScanner\/perl\/custom';
 if [ -f '/etc/MailScanner/MailScanner.conf' ]; then
-	sed -i "s/${OLDTHING}/${NEWTHING}/g" /etc/MailScanner/MailScanner.conf
+    sed -i "s/${OLDTHING}/${NEWTHING}/g" /etc/MailScanner/MailScanner.conf
 fi
 
 # fix the clamav wrapper if the user does not exist
 if [ -d '/etc/clamav' ]; then
 
-	DISTROCAVUSER='ClamUser="clamav"';
-	DISTROCAVGRP='ClamGroup="clamav"';
-	
-	# check for common users and add to the mtagroup
-	if id -u clam >/dev/null 2>&1; then
-		CAVUSR='ClamUser="clam"';
-	fi
+    DISTROCAVUSER='ClamUser="clamav"';
+    DISTROCAVGRP='ClamGroup="clamav"';
 
-	if id -u clamav >/dev/null 2>&1; then
-		CAVUSR='ClamUser="clamav"';
-	fi
-	
-	if id -u clamscan >/dev/null 2>&1; then
-		CAVUSR='ClamUser="clamscan"';
-	fi
-	
-	if id -u vscan >/dev/null 2>&1; then
-		CAVUSR='ClamUser="vscan"';
-	fi
+    # check for common users and add to the mtagroup
+    if id -u clam >/dev/null 2>&1; then
+        CAVUSR='ClamUser="clam"';
+    fi
 
-	if getent group clamav >/dev/null 2>&1; then
-		CAVGRP='ClamGroup="clamav"';
-	fi
+    if id -u clamav >/dev/null 2>&1; then
+        CAVUSR='ClamUser="clamav"';
+    fi
 
-	if getent group clam >/dev/null 2>&1; then
-		CAVGRP='ClamGroup="clam"';
-	fi
-	
-	if getent group clamscan >/dev/null 2>&1; then
-		CAVGRP='ClamGroup="clamscan"';
-	fi
-	
-	if [ -f '/usr/lib/MailScanner/wrapper/clamav-wrapper' ]; then
-		sed -i "s/${DISTROCAVUSER}/${CAVUSR}/g" /usr/lib/MailScanner/wrapper/clamav-wrapper
-		sed -i "s/${DISTROCAVGRP}/${CAVGRP}/g" /usr/lib/MailScanner/wrapper/clamav-wrapper
-	fi
-	
-	# fix old style clamav Monitors if preset in old mailscanner.conf
-	CAVOLD='^Monitors for ClamAV Updates.*';
-	CAVNEW='Monitors for ClamAV Updates = \/usr\/local\/share\/clamav\/\*\.cld \/usr\/local\/share\/clamav\/\*\.cvd \/var\/lib\/clamav\/\*\.inc\/\* \/var\/lib\/clamav\/\*\.\?db \/var\/lib\/clamav\/\*\.cvd';
-	if [ -f '/etc/MailScanner/MailScanner.conf' ]; then
-		sed -i "s/${CAVOLD}/${CAVNEW}/g" /etc/MailScanner/MailScanner.conf
-	fi
+    if id -u clamscan >/dev/null 2>&1; then
+        CAVUSR='ClamUser="clamscan"';
+    fi
+
+    if id -u vscan >/dev/null 2>&1; then
+        CAVUSR='ClamUser="vscan"';
+    fi
+
+    if getent group clamav >/dev/null 2>&1; then
+        CAVGRP='ClamGroup="clamav"';
+    fi
+
+    if getent group clam >/dev/null 2>&1; then
+        CAVGRP='ClamGroup="clam"';
+    fi
+
+    if getent group clamscan >/dev/null 2>&1; then
+        CAVGRP='ClamGroup="clamscan"';
+    fi
+
+    if [ -f '/usr/lib/MailScanner/wrapper/clamav-wrapper' ]; then
+        sed -i "s/${DISTROCAVUSER}/${CAVUSR}/g" /usr/lib/MailScanner/wrapper/clamav-wrapper
+        sed -i "s/${DISTROCAVGRP}/${CAVGRP}/g" /usr/lib/MailScanner/wrapper/clamav-wrapper
+    fi
+
+    # fix old style clamav Monitors if preset in old mailscanner.conf
+    CAVOLD='^Monitors for ClamAV Updates.*';
+    CAVNEW='Monitors for ClamAV Updates = \/usr\/local\/share\/clamav\/\*\.cld \/usr\/local\/share\/clamav\/\*\.cvd \/var\/lib\/clamav\/\*\.inc\/\* \/var\/lib\/clamav\/\*\.\?db \/var\/lib\/clamav\/\*\.cvd';
+    if [ -f '/etc/MailScanner/MailScanner.conf' ]; then
+        sed -i "s/${CAVOLD}/${CAVNEW}/g" /etc/MailScanner/MailScanner.conf
+    fi
 
 fi
 
 # postfix fix
 if [ -f '/etc/postfix/master.cf' ]; then
-	sed -i "s/pickup    unix/pickup    fifo/g" /etc/postfix/master.cf
-	sed -i "s/qmgr      unix/qmgr      fifo/g" /etc/postfix/master.cf
+    sed -i "s/pickup    unix/pickup    fifo/g" /etc/postfix/master.cf
+    sed -i "s/qmgr      unix/qmgr      fifo/g" /etc/postfix/master.cf
 fi
 
 # softlink for custom functions
 if [ -d '/usr/share/MailScanner/perl/custom' -a ! -L '/etc/MailScanner/custom' ]; then
-	ln -s /usr/share/MailScanner/perl/custom /etc/MailScanner/custom
+    ln -s /usr/share/MailScanner/perl/custom /etc/MailScanner/custom
 fi
 
 # softlink for custom reports
 if [ -d '/usr/share/MailScanner/reports' -a ! -L '/etc/MailScanner/reports' ]; then
-	ln -s /usr/share/MailScanner/reports /etc/MailScanner/reports
+    ln -s /usr/share/MailScanner/reports /etc/MailScanner/reports
 fi
 
-# create init.d symlink
-if [ -d '/etc/init.d' -a ! -L '/etc/init.d/mailscanner' -a -f '/usr/lib/MailScanner/init/ms-init' ]; then
-	ln -s /usr/lib/MailScanner/init/ms-init /etc/init.d/mailscanner
-fi
+# RHEL/CentOS7/Fedora >14
+if [ -d '/usr/lib/systemd' ]; then
+   # copy in systemd wrapper and sendmail services
+    if [ -d '/usr/lib/systemd/system' -a ! -e '/usr/lib/systemd/system/mailscanner' -a -f '/usr/lib/MailScanner/systemd/ms-systemd' ]; then
+        cp /usr/lib/MailScanner/systemd/ms-systemd /usr/lib/systemd/system/mailscanner.service
+    fi
+    if [ -d '/usr/lib/systemd/system' -a ! -e '/usr/lib/systemd/system/ms-sendmail' -a -f '/usr/lib/MailScanner/systemd/ms-sendmail' ]; then
+        cp /usr/lib/MailScanner/systemd/ms-sendmail /usr/lib/systemd/system/ms-sendmail.service
+    fi
+    if [ -d '/usr/lib/systemd/system' -a ! -e '/usr/lib/systemd/system/ms-sendmail-in' -a -f '/usr/lib/MailScanner/systemd/ms-sendmail-in' ]; then
+        cp /usr/lib/MailScanner/systemd/ms-sendmail-in /usr/lib/systemd/system/ms-sendmail-in.service
+    fi
+    if [ -d '/usr/lib/systemd/system' -a ! -e '/usr/lib/systemd/system/ms-sendmail-out' -a -f '/usr/lib/MailScanner/systemd/ms-sendmail-out' ]; then
+        cp /usr/lib/MailScanner/systemd/ms-sendmail-out /usr/lib/systemd/system/ms-sendmail-out.service
+    fi
+# RHEL/CentOS6/Fedora <15
+else
+    # create init.d symlink
+    if [ -d '/etc/init.d' -a ! -L '/etc/init.d/mailscanner' -a -f '/usr/lib/MailScanner/init/ms-init' ]; then
+        ln -s /usr/lib/MailScanner/init/ms-init /etc/init.d/mailscanner
+    fi
+    if [ -d '/etc/init.d' -a ! -L '/etc/init.d/ms-sendmail' -a -f '/usr/lib/MailScanner/init/ms-sendmail-init' ]; then
+        ln -s /usr/lib/MailScanner/init/ms-sendmail-init /etc/init.d/ms-sendmail
+    fi
 
-# Sort out the rc.d directories
-chkconfig --add mailscanner
+    # Sort out the rc.d directories
+    chkconfig --add mailscanner
+    chkconfig --add ms-sendmail   
+fi
 
 echo
 echo
@@ -507,9 +570,24 @@ echo
 echo
 echo To activate MailScanner run the following commands:
 echo
+echo    --SysV Init--
 echo    chkconfig mailscanner on
 echo    service mailscanner start
 echo
+echo    --Systemd--
+echo    systemctl enable mailscanner.service
+echo    systemctl start mailscanner.service
+echo
+echo To activate Sendmail for Mailscanner \(if in use\) run the following commands:
+echo
+echo    --SysV Init--
+echo    chkconfig ms-sendmail on
+echo    service ms-sendmail start
+echo
+echo    --Systemd--
+echo    systemctl enable ms-sendmail.service
+echo    systemctl start ms-sendmail.service
+
 echo
 
 exit 0 
@@ -517,16 +595,31 @@ exit 0
 %preun
 if [ $1 = 0 ]; then
     # We are being deleted, not upgraded
-    service mailscanner stop >/dev/null 2>&1
-    chkconfig mailscanner off
-    chkconfig --del mailscanner
+    if [ -d '/usr/lib/systemd' ]; then
+        systemctl stop mailscanner.service >/dev/null 2>&1
+        systemctl disable mailscanner.service
+        rm -f /usr/lib/systemd/system/mailscanner.service
+        systemctl stop ms-sendmail.service >/dev/null 2>&1
+        systemctl disable ms-sendmail.service >/dev/null 2>&1
+        rm -f /usr/lib/systemd/system/ms-sendmail.service
+        rm -f /usr/lib/systemd/system/ms-sendmail-in.service
+        rm -f /usr/lib/systemd/system/ms-sendmail-out.service
+    else
+        service mailscanner stop >/dev/null 2>&1
+        service ms-sendmail stop >/dev/null 2>&1
+        chkconfig mailscanner off
+        chkconfig ms-sendmail off
+        chkconfig --del mailscanner
+        rm -f /etc/init.d/mailscanner
+        chkconfig --del ms-sendmail
+        rm -f /etc/init.d/ms-sendmail
 fi
 exit 0
 
 %postun
 # delete old ms files if this is an upgrade
 if [ -d '/var/lib/MailScanner' ]; then
-	rm -rf /var/lib/MailScanner
+    rm -rf /var/lib/MailScanner
 fi
 exit 0
 
@@ -538,6 +631,7 @@ exit 0
 %attr(755,root,root) %dir /etc/MailScanner/conf.d
 %attr(755,root,root) %dir /usr/lib/MailScanner/wrapper
 %attr(755,root,root) %dir /usr/lib/MailScanner/init
+%attr(755,root,root) %dir /usr/lib/MailScanner/systemd
 %attr(755,root,root) %dir /var/spool/MailScanner/archive
 %attr(755,root,root) %dir /var/spool/MailScanner/incoming
 %attr(755,root,root) %dir /var/spool/MailScanner/quarantine
@@ -566,6 +660,11 @@ exit 0
 %attr(755,root,root) /usr/sbin/ms-upgrade-conf
 
 %attr(755,root,root) /usr/lib/MailScanner/init/ms-init
+%attr(755,root,root) /usr/lib/MailScanner/init/ms-sendmail-init
+%attr(755,root,root) /usr/lib/MailScanner/systemd/ms-systemd
+%attr(755,root,root) /usr/lib/MailScanner/systemd/ms-sendmail
+%attr(755,root,root) /usr/lib/MailScanner/systemd/ms-sendmail-in
+%attr(755,root,root) /usr/lib/MailScanner/systemd/ms-sendmail-out
 
 %attr(755,root,root) /usr/lib/MailScanner/wrapper/avast-wrapper
 %attr(755,root,root) /usr/lib/MailScanner/wrapper/avg-autoupdate
@@ -1078,6 +1177,9 @@ exit 0
 
 
 %changelog
+* Wed May 3 2017 Shawn Iverson <shawniverson@gmail.com>
+- Add RHEL/CentOS 7 systemd support for mailscanner and sendmail
+
 * Thu Nov 10 2016 Jerry Benton <mailscanner@mailborder.com>
 - see https://github.com/MailScanner/v5/blob/master/changelog
 

--- a/rhel/usr/lib/MailScanner/init/ms-sendmail-init
+++ b/rhel/usr/lib/MailScanner/init/ms-sendmail-init
@@ -1,0 +1,194 @@
+#!/bin/bash
+#
+# mailscanner-sendmail   This shell script takes care of starting and stopping
+#                        the sendmail processes as needed by mailscanner
+#
+# chkconfig: 2345 79 30
+# description: start sendmail queues for mailscanner
+# processname: mailscanner-sendmail
+# pidfile: /var/run/sendmail.*.pid, /var/run/sm-client.pid
+
+### BEGIN INIT INFO
+# Provides:          sendmail mail-transport-agent
+# Required-Start:    $local_fs $remote_fs $syslog $named $network $time
+# Required-Stop:     $local_fs $remote_fs $syslog $named $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Sendmail Mail Transport Agent
+# Description:       sendmail is a Mail Transport agent
+### END INIT INFO
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+# Source networking configuration.
+. /etc/sysconfig/network
+
+MTA=sendmail
+QUEUETIME=15m
+WORKDIR=/var/spool/MailScanner/incoming
+QUARDIR=/var/spool/MailScanner/quarantine
+INQDIR=/var/spool/mqueue.in
+RUNAS=root
+INPID=/var/run/sendmail.in.pid
+OUTPID=/var/run/sendmail.out.pid
+SMPID=/var/run/sm-client.pid
+MSPUSER=smmsp
+MSPGROUP=smmsp
+SENDMAIL=/usr/sbin/sendmail
+RESTART_DELAY=10
+
+export HOSTNAME
+export MTA
+export QUEUETIME
+export WORKDIR
+export QUARDIR
+export INQDIR
+export RUNAS
+export INPID
+export OUTPID
+export SMPID
+export MSPUSER
+export MSPGROUP
+export SENDMAIL
+export RESTART_DELAY
+
+# Check that networking is up.
+if [ -n ${NETWORKING} ]; then
+    [ ${NETWORKING} = "no" ] && exit 0
+fi
+
+[ -f $SENDMAIL ] || exit 0
+
+# Start both sendmail processes
+StartInSendmail() {
+      if [ $MTA = 'sendmail' ]; then
+        /usr/bin/newaliases > /dev/null 2>&1
+        if test -x /usr/bin/make -a -f /etc/mail/Makefile ; then
+            make -C /etc/mail -s
+        else
+            for i in virtusertable access domaintable mailertable ; do
+                if [ -f /etc/mail/$i ] ; then
+                    makemap hash /etc/mail/$i < /etc/mail/$i
+                fi
+            done
+        fi
+        $SENDMAIL -bd -OPrivacyOptions=noetrn \
+                      -ODeliveryMode=queueonly \
+                      -OQueueDirectory=$INQDIR \
+                      -OPidFile=$INPID 
+        # rhbz#200920
+        if [ ! -f $SMPID ]; then
+            touch $SMPID
+            chown $MSPUSER:$MSPGROUP $SMPID 2>/dev/null
+            if [ -x /usr/sbin/selinuxenabled ] && /usr/sbin/selinuxenabled; then
+                /sbin/restorecon $SMPID
+            fi
+        fi
+        $SENDMAIL -L sm-msp-queue -Ac -q15m -OPidFile=$SMPID 2>/dev/null
+        success
+        echo
+      else
+        failure
+        echo
+      fi
+}
+StartOutSendmail() {
+      if [ $MTA = 'sendmail' ]; then
+        $SENDMAIL $([ -n "$QUEUETIME" ] && echo -q$QUEUETIME) \
+                  -OPidFile=$OUTPID
+        success
+        echo
+      else
+        failure
+        echo
+      fi
+}
+
+RETVAL=0
+
+# See how we were called.
+case "$1" in
+  startin)
+    # Start just incoming sendmail
+    echo "Starting incoming $MTA only:"
+    echo -n '         incoming' $MTA': '
+    StartInSendmail
+    ;;
+  startout)
+    # Start just outgoing sendmail
+    echo "Starting outgoing $MTA only:"
+    echo -n '         outgoing' $MTA': '
+    StartOutSendmail
+    ;;
+  start)
+        [ -x /sbin/portrelease ] && /sbin/portrelease smtp &>/dev/null || :
+    # Start daemons.
+        echo 'Starting sendmail daemons:'
+        echo -n '         incoming' $MTA': '
+    StartInSendmail
+        echo -n '         outgoing' $MTA': '
+    StartOutSendmail
+    RETVAL=$?
+    [ $RETVAL -eq 0 ] && touch /var/lock/subsys/mailscanner-sendmail
+    ;;
+  stop)
+    # Stop daemons.
+        echo 'Stopping sendmail daemons:'
+    echo -n '         incoming' $MTA': '
+        if [ $MTA = "sendmail" ]; then
+          #killproc sendmail 2>/dev/null
+          [ -r $INPID ] && kill `head -1 $INPID` 2>/dev/null
+          [ -r /var/run/sm-client.pid ] && \
+          kill `head -1 /var/run/sm-client.pid` 2>/dev/null
+          success
+    else
+          failure
+          echo
+        fi
+    echo
+    echo -n '         outgoing' $MTA': '
+        if [ $MTA = "sendmail" ]; then
+          #killproc /usr/sbin/sendmail 2>/dev/null
+          [ -r $OUTPID ] && kill `head -1 $OUTPID` 2>/dev/null
+          success
+        else
+          failure
+          echo
+        fi
+    RETVAL=$?
+    echo
+    [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/mailscanner-sendmail
+    # Clear out the old incoming dirs
+    cd $WORKDIR && ls | egrep '^[0123456789]+$' | xargs /bin/rm -rf 2>/dev/null
+    ;;
+  status)
+        # Work out if sendmail daemons are running
+    echo    'Checking sendmail daemons:'
+    if [ $MTA = "sendmail" ]; then
+          # Now the incoming sendmail
+          echo -n '         incoming sendmail: '
+      alive=`ps axww | grep 'mqueue.i[n]' | awk '{ print $1 }' | head -1`
+      [ -r $INPID ] && pid=`head -1 $INPID` && alive=`ps ax | awk '{ print $1 }' | grep '^'$pid'$'`
+          if [ -z "$alive" ] ; then failure; else success; fi
+          echo
+          # Now the outgoing sendmail
+          echo -n '         outgoing sendmail: '
+      alive=
+      [ -r $OUTPID ] && pid=`head -1 $OUTPID` && alive=`ps ax | awk '{ print $1 }' | grep '^'$pid'$'`
+          if [ -z "$alive" ] ; then failure; else success; fi
+          echo
+        fi
+        ;;
+  restart)
+    $0 stop
+        sleep 1
+    $0 start
+    RETVAL=$?
+    ;;
+  *)
+    echo "Usage: service mailscanner-sendmail {start|stop|status|restart|restartms|reload|startin|startout|stopms}"
+    exit 1
+esac
+
+exit $RETVAL

--- a/rhel/usr/lib/MailScanner/systemd/ms-sendmail
+++ b/rhel/usr/lib/MailScanner/systemd/ms-sendmail
@@ -1,0 +1,20 @@
+[Unit]
+Description=Sendmail Mail Transport Client for MailScanner
+After=syslog.target network.target
+Conflicts=postfix.service exim.service sendmail.service sm-client.service
+Wants=ms-sendmail-in.service ms-sendmail-out.service
+BindsTo=ms-sendmail-in.service ms-sendmail-out.service
+
+[Service]
+Type=forking
+PIDFile=/run/sm-client.pid
+Environment=SENDMAIL_OPTS=-q1h
+ExecStartPre=/bin/touch /run/sm-client.pid
+ExecStartPre=/bin/chown smmsp:smmsp /run/sm-client.pid
+ExecStartPre=-/sbin/restorecon /run/sm-client.pid
+ExecStartPre=-/etc/mail/make
+ExecStart=/usr/sbin/sendmail -L sm-msp-queue -Ac $SENDMAIL_OPTS
+
+[Install]
+WantedBy=multi-user.target
+Also=ms-sendmail-in.service ms-sendmail-out.service

--- a/rhel/usr/lib/MailScanner/systemd/ms-sendmail-in
+++ b/rhel/usr/lib/MailScanner/systemd/ms-sendmail-in
@@ -1,0 +1,15 @@
+[Unit]
+Description=Sendmail Mail Transport Inbound Agent for MailScanner
+After=syslog.target network.target
+Conflicts=postfix.service exim.service sendmail.service sm-client.service
+Wants=ms-sendmail.service ms-sendmail-out.service
+BindsTo=ms-sendmail.service ms-sendmail-out.service
+
+[Service]
+Type=forking
+PIDFile=/run/sendmail.in.pid
+ExecStart=/usr/sbin/sendmail -bd -OPrivacyOptions=noetrn -ODeliveryMode=queueonly -OQueueDirectory=/var/spool/mqueue.in -OPidFile=/run/sendmail.in.pid
+
+[Install]
+WantedBy=multi-user.target
+Also=ms-sendmail.service ms-sendmail-out.service

--- a/rhel/usr/lib/MailScanner/systemd/ms-sendmail-out
+++ b/rhel/usr/lib/MailScanner/systemd/ms-sendmail-out
@@ -1,0 +1,15 @@
+[Unit]
+Description=Sendmail Mail Transport Outbound Agent for MailScanner
+After=syslog.target network.target
+Conflicts=postfix.service exim.service sendmail.service sm-client.service
+Wants=ms-sendmail.service ms-sendmail-in.service
+BindsTo=ms-sendmail.service ms-sendmail-in.service
+
+[Service]
+Type=forking
+PIDFile=/run/sendmail.out.pid
+ExecStart=/usr/sbin/sendmail -q15m -OPidFile=/run/sendmail.out.pid
+
+[Install]
+WantedBy=multi-user.target
+Also=ms-sendmail.service ms-sendmail-in.service

--- a/suse/mailscanner.spec
+++ b/suse/mailscanner.spec
@@ -53,7 +53,7 @@ mkdir -p ${RPM_BUILD_ROOT}/etc/MailScanner/{conf.d,rules,mcp}
 mkdir -p ${RPM_BUILD_ROOT}/etc/{cron.hourly,cron.daily}
 mkdir -p ${RPM_BUILD_ROOT}/usr/share/MailScanner/reports/{hu,de,se,ca,cy+en,pt_br,fr,es,en,cz,it,dk,nl,ro,sk}
 mkdir -p ${RPM_BUILD_ROOT}/usr/share/MailScanner/perl/{MailScanner,custom}
-mkdir -p ${RPM_BUILD_ROOT}/usr/{lib/MailScanner/wrapper,lib/MailScanner/init}
+mkdir -p ${RPM_BUILD_ROOT}/usr/{lib/MailScanner/wrapper,lib/MailScanner/init,lib/MailScanner/systemd}
 mkdir -p ${RPM_BUILD_ROOT}/var/spool/MailScanner/{archive,incoming,quarantine}
 
 ### etc
@@ -220,6 +220,7 @@ EOF
 ### usr/lib/MailScanner
 
 install usr/lib/MailScanner/init/ms-init ${RPM_BUILD_ROOT}/usr/lib/MailScanner/init/
+install usr/lib/MailScanner/systemd/ms-systemd ${RPM_BUILD_ROOT}/usr/lib/MailScanner/systemd/
 
 while read f 
 do
@@ -271,6 +272,12 @@ fi
 if [ -f '/etc/init.d/MailScanner' ]; then
 	chkconfig --del MailScanner >/dev/null 2>&1
 	rm -f /etc/init.d/MailScanner
+fi
+
+# remove systemd if present
+if [ -f '/usr/lib/systemd/system/mailscanner.service' ]; then
+    systemctl disable mailscanner.service
+    rm -f /usr/lib/systemd/system/mailscanner.service
 fi
 
 if [ -d '/usr/lib/MailScanner/MailScanner/CustomFunctions' ]; then
@@ -507,13 +514,15 @@ if [ -d '/usr/share/MailScanner/reports' -a ! -L '/etc/MailScanner/reports' ]; t
 	ln -s /usr/share/MailScanner/reports /etc/MailScanner/reports
 fi
 
+# Check for systemd
+if [ -d '/usr/lib/systemd' -a -f '/usr/lib/MailScanner/systemd/ms-systemd' ]; then
+    cp /usr/lib/MailScanner/systemd/ms-systemd /usr/lib/systemd/system/mailscanner.service
 # create init.d symlink
-if [ -d '/etc/init.d' -a ! -L '/etc/init.d/mailscanner' -a -f '/usr/lib/MailScanner/init/ms-init' ]; then
-	ln -s /usr/lib/MailScanner/init/ms-init /etc/init.d/mailscanner
+elif [ -d '/etc/init.d' -a ! -L '/etc/init.d/mailscanner' -a -f '/usr/lib/MailScanner/init/ms-init' ]; then
+    ln -s /usr/lib/MailScanner/init/ms-init /etc/init.d/mailscanner
+    # Sort out the rc.d directories
+    chkconfig --add mailscanner
 fi
-
-# Sort out the rc.d directories
-chkconfig --add mailscanner
 
 echo
 echo
@@ -525,8 +534,13 @@ echo
 echo
 echo To activate MailScanner run the following commands:
 echo
+echo    --SysV Init--
 echo    chkconfig mailscanner on
 echo    service mailscanner start
+echo
+echo    --Systemd--
+echo    systemctl enable mailscanner.service
+echo    systemctl start mailscanner.service
 echo
 echo
 
@@ -554,6 +568,7 @@ exit 0
 %attr(755,root,root) %dir /etc/MailScanner/conf.d
 %attr(755,root,root) %dir /usr/lib/MailScanner/wrapper
 %attr(755,root,root) %dir /usr/lib/MailScanner/init
+%attr(755,root,root) %dir /usr/lib/MailScanner/systemd
 %attr(755,root,root) %dir /var/spool/MailScanner/archive
 %attr(755,root,root) %dir /var/spool/MailScanner/incoming
 %attr(755,root,root) %dir /var/spool/MailScanner/quarantine
@@ -582,6 +597,7 @@ exit 0
 %attr(755,root,root) /usr/sbin/ms-upgrade-conf
 
 %attr(755,root,root) /usr/lib/MailScanner/init/ms-init
+%attr(755,root,root) /usr/lib/MailScanner/systemd/ms-systemd
 
 %attr(755,root,root) /usr/lib/MailScanner/wrapper/avast-wrapper
 %attr(755,root,root) /usr/lib/MailScanner/wrapper/avg-autoupdate
@@ -1094,6 +1110,9 @@ exit 0
 
 
 %changelog
+* Sun May 28 2017 Shawn Iverson <shawniverson@gmail.com>
+- mailscanner systemd support for SuSE Linux
+
 * Thu Nov 10 2016 Jerry Benton <mailscanner@mailborder.com>
 - see https://github.com/MailScanner/v5/blob/master/changelog
 


### PR DESCRIPTION
Not ready to merge...PRing for testing purposes

Info:
the ms-init script is complex and will be difficult to port as a pure systemd script.  A simple alternative is to use systemd to call the ms-init script instead so that everything is taken care of, otherwise the systemd unit will be loaded full of Environment defs, StartExecPre, StartExecPost, StopExecPre, StopExecPost, etc. and some of the logic will be lost.

cleanup mailscanner.spec spacing
add systemd logic
add ms-systemd
add ms-sendmail* for RHEL based systems (debian and SUSE appear to be ok as is)