### PR TITLE
Pass $MTAOPTION without quotes

### DIFF
--- a/debian/install.sh
+++ b/debian/install.sh
@@ -307,7 +307,7 @@ done
 
 # install this separate in case it conflicts
 if [ "x$MTAOPTION" != "x" ]; then
-	$APTGET -yf install "$MTAOPTION"
+	$APTGET -yf install $MTAOPTION
 fi
 
 # fix the stupid line in /etc/freshclam.conf that disables freshclam 


### PR DESCRIPTION
Sendmail will not install on debian if this is quoted.  "sendmail sendmail-bin" will be interpreted as a single string, and command will fail.