### PR TITLE
Spec fixes for MailScanner on rhel and suse

### DIFF
--- a/rhel/mailscanner.spec
+++ b/rhel/mailscanner.spec
@@ -261,13 +261,11 @@ SAVEDIR="$HOME/ms_upgrade/saved.$$";
 
 # remove old symlink if present
 if [ -L '/etc/init.d/mailscanner' ]; then
-    chkconfig --del mailscanner >/dev/null 2>&1
     rm -f /etc/init.d/mailscanner
 fi
 
 # remove old file if present
 if [ -f '/etc/init.d/mailscanner' ]; then
-    chkconfig --del mailscanner >/dev/null 2>&1
     rm -f /etc/init.d/mailscanner
 fi
 
@@ -279,37 +277,32 @@ fi
 
 # remove old file if present
 if [ -f '/etc/init.d/MailScanner' ]; then
-   chkconfig --del MailScanner >/dev/null 2>&1
-   rm -f /etc/init.d/MailScanner
+    chkconfig --del MailScanner >/dev/null 2>&1
+    rm -f /etc/init.d/MailScanner
 fi
 
 # remove old file if present
 if [ -f '/usr/lib/systemd/system/mailscanner' ]; then
-   systemctl disable mailscanner >/dev/null 2>&1
    rm -f /usr/lib/systemd/system/mailscanner
 fi
 
 # remove old file if present
 if [ -f '/etc/init.d/ms-sendmail' ]; then
-   chkconfig --del ms-sendmail >/dev/null 2>&1
    rm -f /etc/init.d/ms-sendmail
 fi
 
 # remove old file if present
 if [ -f '/usr/lib/systemd/system/ms-sendmail' ]; then
-   systemctl disable ms-sendmail >/dev/null 2>&1
    rm -f /usr/lib/systemd/system/ms-sendmail
 fi
 
 # remove old file if present
 if [ -f '/usr/lib/systemd/system/ms-sendmail-in' ]; then
-   systemctl disable ms-sendmail-in >/dev/null 2>&1
    rm -f /usr/lib/systemd/system/ms-sendmail-in
 fi
 
 # remove old file if present
 if [ -f '/usr/lib/systemd/system/ms-sendmail-out' ]; then
-   systemctl disable ms-sendmail-out >/dev/null 2>&1
    rm -f /usr/lib/systemd/system/ms-sendmail-out
 fi
 
@@ -550,8 +543,16 @@ else
     fi
 
     # Sort out the rc.d directories
-    chkconfig --add mailscanner
-    chkconfig --add ms-sendmail   
+    chkconfig --list mailscanner >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        chkconfig --add mailscanner
+        chkconfig mailscanner off
+    fi
+    chkconfig --list ms-sendmail >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        chkconfig --add ms-sendmail
+        chkconfig ms-sendmail off
+    fi
 fi
 
 echo
@@ -633,7 +634,7 @@ exit 0
 %attr(755,root,root) %dir /usr/lib/MailScanner/systemd
 %attr(755,root,root) %dir /var/spool/MailScanner/archive
 %attr(755,root,root) %dir /var/spool/MailScanner/incoming
-%attr(755,root,root) %dir /var/spool/MailScanner/quarantine
+#%attr(755,root,root) %dir /var/spool/MailScanner/quarantine
 %attr(755,root,root) %dir /usr/share/MailScanner
 %attr(755,root,root) %dir /usr/share/MailScanner/perl
 %attr(755,root,root) %dir /usr/share/MailScanner/perl/custom
@@ -1175,6 +1176,9 @@ exit 0
 
 
 %changelog
+* Sun Sep 03 2017 Shawn Iverson <shawniverson@gmail.com>
+- Preserve quarantine perms and better init runlevel handling
+
 * Sun Aug 27 2017 Shawn Iverson <shawniverson@gmail.com>
 - Remove execute bit on systemd scripts/update instructions
 

--- a/suse/mailscanner.spec
+++ b/suse/mailscanner.spec
@@ -251,13 +251,11 @@ SAVEDIR="$HOME/ms_upgrade/saved.$$";
 
 # remove old symlink if present
 if [ -L '/etc/init.d/mailscanner' ]; then
-	chkconfig --del mailscanner >/dev/null 2>&1
 	rm -f /etc/init.d/mailscanner
 fi
 
 # remove old file if present
 if [ -f '/etc/init.d/mailscanner' ]; then
-	chkconfig --del mailscanner >/dev/null 2>&1
 	rm -f /etc/init.d/mailscanner
 fi
 
@@ -275,7 +273,6 @@ fi
 
 # remove systemd if present
 if [ -f '/usr/lib/systemd/system/mailscanner.service' ]; then
-    systemctl disable mailscanner.service
     rm -f /usr/lib/systemd/system/mailscanner.service
 fi
 
@@ -515,7 +512,11 @@ if [ -f '/lib/systemd/systemd' -o -f '/usr/lib/systemd/systemd' ]; then
 elif [ -d '/etc/init.d' -a ! -L '/etc/init.d/mailscanner' -a -f '/usr/lib/MailScanner/init/ms-init' ]; then
     ln -s /usr/lib/MailScanner/init/ms-init /etc/init.d/mailscanner
     # Sort out the rc.d directories
-    chkconfig --add mailscanner
+    chkconfig --list mailscanner >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        chkconfig --add mailscanner
+        chkconfig mailscanner off
+    fi
 fi
 
 echo
@@ -565,7 +566,7 @@ exit 0
 %attr(755,root,root) %dir /usr/lib/MailScanner/systemd
 %attr(755,root,root) %dir /var/spool/MailScanner/archive
 %attr(755,root,root) %dir /var/spool/MailScanner/incoming
-%attr(755,root,root) %dir /var/spool/MailScanner/quarantine
+#%attr(755,root,root) %dir /var/spool/MailScanner/quarantine
 %attr(755,root,root) %dir /usr/share/MailScanner
 %attr(755,root,root) %dir /usr/share/MailScanner/perl
 %attr(755,root,root) %dir /usr/share/MailScanner/perl/custom
@@ -1103,6 +1104,9 @@ exit 0
 
 
 %changelog
+* Sun Sep 03 2017 Shawn Iverson <shawniverson@gmail.com>
+- Preserve quarantine perms and better init runlevel handling
+
 * Sun Aug 27 2017 Shawn Iverson <shawniverson@gmail.com>
 - Remove execute bit on systemd script
 


### PR DESCRIPTION
Preserve permissions/ownership of existing /var/spool/MailScanner/quarantine (don't explicitly include in %files, let script create it if not present).  Fixes issue #88 .

Better init/systemd state handling.  Don't disable mailscanner (and ms-sendmail) if they are already enabled during update process by not removing runlevel/systemd symlinks during %pre, and make sure they are added and off during fresh install during %post.



