### PR TITLE
Fix parsing an email address into local-part and domain

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/Message.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Message.pm
@@ -477,7 +477,7 @@ sub address2userdomain {
 
   if ($addr =~ /@/) {
     $user   =~ s/@[^@]*$//;
-    $domain =~ s/^[^@]*@//;
+    $domain =~ s/^.*@//;
   }
 
   return ($user, $domain);


### PR DESCRIPTION
Fixes #109 

Email addresses containing a quoted @ in the local part parsed the domain incorrectly.