### PR TITLE
Only run freshclam if it is not running yet

### DIFF
--- a/debian/install.sh
+++ b/debian/install.sh
@@ -630,7 +630,10 @@ else
     /usr/sbin/ms-update-phishing >/dev/null 2>&1
     
     if [ -d '/etc/clamav' ]; then
-        /usr/bin/freshclam 2>/dev/null
+        #Test if freshclam is already running
+        if [[ -z $(ps aux | grep "[f]reshclam") ]]; then
+            /usr/bin/freshclam 2>/dev/null
+        fi
     fi
     
     echo;


### PR DESCRIPTION
Currently there is an error if the freshclam daemon is already running and the script tries to start freshclam.

Probably also useful in other install scripts but not tested