### PR TITLE
Introduce option to disable rbl check if user is authenticated to mta (#128)

### DIFF
--- a/common/etc/MailScanner/MailScanner.conf
+++ b/common/etc/MailScanner/MailScanner.conf
@@ -2057,6 +2057,11 @@ Spam Lists To Reach High Score = 3
 # that this (in seconds), the check is abandoned and the timeout noted.
 Spam List Timeout = 10
 
+# (yes/no) If an user sends a mails after authenticating to the local mta
+# this option disables the rbl checks if set to "yes". If set to "no" or not
+# defined the rbl check will be executed even when the user is authenticated.
+Spam List Skip If Authenticated = no
+
 # The maximum number of timeouts caused by any individual "Spam List" or
 # "Spam Domain List" before it is marked as "unavailable". Once marked,
 # the list will be ignored until the next automatic re-start (see

--- a/common/etc/MailScanner/MailScanner.conf
+++ b/common/etc/MailScanner/MailScanner.conf
@@ -2057,7 +2057,8 @@ Spam Lists To Reach High Score = 3
 # that this (in seconds), the check is abandoned and the timeout noted.
 Spam List Timeout = 10
 
-# (yes/no) If an user sends a mails after authenticating to the local mta
+# Postfix only: (yes/no)
+# If an user sends a mails after authenticating to the local mta
 # this option disables the rbl checks if set to "yes". If set to "no" or not
 # defined the rbl check will be executed even when the user is authenticated.
 Spam List Skip If Authenticated = no

--- a/common/usr/share/MailScanner/perl/MailScanner/ConfigDefs.pl
+++ b/common/usr/share/MailScanner/perl/MailScanner/ConfigDefs.pl
@@ -284,6 +284,7 @@ expandtnef		1	no	0	yes	1
 runinforeground		0	no	0	yes	1
 showscanner		1	no	0	yes	1
 spamassassinautowhitelist 1	no	0	yes	1
+spamlistskipifauthenticated	0       no      0       yes     1
 spliteximspool		0	no	0	yes	1
 storeentireasdfqf	0	no	0	yes	1
 syntaxcheck		1	no	0	yes	1

--- a/common/usr/share/MailScanner/perl/MailScanner/Message.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Message.pm
@@ -711,7 +711,20 @@ sub IsSpam {
     return 0;
   }
 
-  if (!$iswhitelisted) {
+  my $isauthenticated = 0;
+  if (MailScanner::Config::Value('spamlistskipifauthenticated')) {
+#      MailScanner::Log::InfoLog(Dumper($metadata));
+    # Test if sender is authenticated on mta
+    foreach my $metadata (@{$this->{metadata}}) {
+      #Postfix
+      if ($metadata =~ m/^Asasl_method=(PLAIN|LOGIN)$/) {
+        MailScanner::Log::InfoLog("Sender was authenticated - Not checking RBLs");
+        $isauthenticated = 1;
+      }
+    }
+  }
+
+  if (!$iswhitelisted && !$isauthenticated) {
     # Not whitelisted, so do the RBL checks
     $0 = 'MailScanner: checking with Spam Lists';
     ($rblcounter, $rblspamheader) = MailScanner::RBLs::Checks($this);

--- a/common/usr/share/MailScanner/perl/MailScanner/Message.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Message.pm
@@ -47,6 +47,7 @@ use File::Temp;
 use MailScanner::FileInto;
 use IO::Pipe;
 use IO::File;
+#use Data::Dumper;
 
 # Install an extra MIME decoder for badly-header uue messages.
 install MIME::Decoder::UU 'uuencode';

--- a/common/usr/share/MailScanner/perl/MailScanner/Message.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Message.pm
@@ -713,7 +713,7 @@ sub IsSpam {
   }
 
   my $isauthenticated = 0;
-  if (MailScanner::Config::Value('spamlistskipifauthenticated')) {
+  if (MailScanner::Config::Value('mta') == "postfix" && MailScanner::Config::Value('spamlistskipifauthenticated')) {
 #      MailScanner::Log::InfoLog(Dumper($metadata));
     # Test if sender is authenticated on mta
     foreach my $metadata (@{$this->{metadata}}) {


### PR DESCRIPTION
See issue #128 
Currently only tested on postfix.
Can someone with exim or sendmail knowledge/setup use mta authentication and uncomment
`#use Data::Dumper;` and `#      MailScanner::Log::InfoLog(Dumper($metadata));` and check if it matches with the postfix metadata (in the mail.log) or post that output:
`... MailScanner[57106]: $VAR1 = 'Asasl_method=PLAIN';`
