### PR TITLE
Fix Issue #149

### DIFF
--- a/common/usr/lib/MailScanner/systemd/ms-systemd
+++ b/common/usr/lib/MailScanner/systemd/ms-systemd
@@ -16,7 +16,7 @@ RemainAfterExit=yes
 ExecStart=/usr/lib/MailScanner/init/ms-init start
 ExecStop=/usr/lib/MailScanner/init/ms-init stop
 EnvironmentFile=-/etc/MailScanner/defaults
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=/usr/lib/MailScanner/init/ms-init reload
 PIDFile=/var/run/MailScanner.pid
 
 [Install]

--- a/common/usr/sbin/ms-update-phishing
+++ b/common/usr/sbin/ms-update-phishing
@@ -316,32 +316,32 @@ if [ $updated -ge 1 ]; then
     if [ ! -f /var/lock/subsys/MailScanner.off ]; then
       logger -p $SYSLOG.info -t ms-update-phishing reload MailScanner....
       if [ -d /etc/systemd ]; then
-        systemctl reload $MSSERVICENAME > /dev/null 2>&1
+        systemctl reload $MSSERVICENAME >/dev/null 2>&1
         if [ $? != 0 ] ; then
           #echo "MailScanner reload failed - Retrying..."
-          systemctl reload $MSSERVICENAME > /dev/null 2>&1
+          systemctl reload $MSSERVICENAME >/dev/null 2>&1
           if [ $? != 0 ] ; then
             #echo "Stopping MailScanner..."
-            systemctl stop $MSSERVICENAME
+            systemctl stop $MSSERVICENAME >/dev/null 2>&1
             #echo "Waiting for a minute..."
             perl -e "sleep 60;"
             #echo "Attemping to start MailScanner..."
-            systemctl start $MSSERVICENAME
+            systemctl start $MSSERVICENAME >/dev/null 2>&1
           fi
         fi
       else
         if [ -s $MSSTARTSCRIPT ]; then
-          $MSSTARTSCRIPT reload > /dev/null 2>&1
+          $MSSTARTSCRIPT reload >/dev/null 2>&1
           if [ $? != 0 ] ; then
             #echo "MailScanner reload failed - Retrying..."
-            $MSSTARTSCRIPT reload
+            $MSSTARTSCRIPT reload >/dev/null 2>&1
             if [ $? != 0 ] ; then
               #echo "Stopping MailScanner..."
-              $MSSTARTSCRIPT stop
+              $MSSTARTSCRIPT stop >/dev/null 2>&1
               #echo "Waiting for a minute..."
               perl -e "sleep 60;"
               #echo "Attemping to start MailScanner..."
-              $MSSTARTSCRIPT start
+              $MSSTARTSCRIPT start >/dev/null 2>&1
             fi
           fi
         fi


### PR DESCRIPTION
Suppress output for cron
Use ms-init reload for ExecReload instead of kill o prevent detacting custom perl module children from process tree.