### PR TITLE
FIX: Untaint the $safename var in unpack7zip

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/Message.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Message.pm
@@ -3189,6 +3189,8 @@ sub Unpack7zip {
     $nopathname = $name;
     $nopathname =~ s/^.*\///;
     $safename = $this->MakeNameSafe('r'.$nopathname,$explodeinto);
+    $safename =~ m|(.*)|;
+    $safename = $1;
     $NameTwo = $safename;
     $NameTwo = $1 if $NameTwo =~ /([^\/]+)$/;
     #MailScanner::Log::InfoLog("UnPackRar: Member : %s", $member);


### PR DESCRIPTION
Prevent the taint error in open when the file is encrypted.