### PR TITLE
Message::SafePipe: make sure $? respect process exit code

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/Message.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Message.pm
@@ -3572,6 +3572,7 @@ sub SafePipe {
         $Str .= $_;
         #print STDERR "SafePipe : Processing line \"$_\"\n";
       }
+      close $Kid;
 
       #MailScanner::Log::DebugLog("SafePipe : Completed $Cmd");
       #print STDERR "SafePipe : Returned $PipeReturnCode\n";


### PR DESCRIPTION
The return value for the process is reset on top of `SafePipe`, but not returned to the calling process, as the command pipe is read but not explicitly [close](https://perldoc.perl.org/functions/close.html)d.
