### PR TITLE
Fix Configuration chaining for Sa rules actions in rulesets

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/Config.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Config.pm
@@ -692,14 +692,9 @@ sub AllMatchesValue {
   }
 
   # Return the concatenation of all the matching rules
-  my($results);
-  $results = join(" ", @matches);
-  #print STDERR "Result is \"$results\"\n";
-  return $results if @matches; # JKF $results ne "";
-  # Nothing matched, so return the default value
-  #print STDERR "Nothing matched, so returning default\n";
-  #return $Defaults{$name};
-  return "CoNfIgFoUnDnOtHiNg";
+  return "CoNfIgFoUnDnOtHiNg" unless @matches;
+  return join(",", @matches) if $name eq 'saactions';
+  return join(" ", @matches);
 }
 
 


### PR DESCRIPTION
This is a followup of PR #47

## Quick Fix

I found out that the same problem of joining by space instead of commas for SpamAssassin actions apply also to rulesets.

This fix is almost identical as the previous PR, but I removed misleading comments.

## A Better (?) Fix

Too long; please read. :)

### The Problem

I think there is a problem in the way of "All Match" ruleset are applied.

Suppose I have this ruleset (example for boolean):

```txt
From:        me@domain-1.test Yes
FromOrTo:    .*@domain.*      No
FromOrTo:    .*@domain-2.test Yes
```
Now an email "From: A@domain-1.test To: B@domain-2.test Cc: C@domain-2.test " pass through. I would expect the ruleset to evaluate to `[No, Yes]` (line 2 + line 3), which eventually become yes; what really is evaluated is `[No, No, No, Yes, Yes]` (line 2 per 3 addresses, and line 3 per 2 addresses). In the end the result is the same, just wasted a lot of time to conclude the same thing.

The problem arise with SpamAssassin actions. Let's write an example similar to the previous:

```txt
From:        me@domain-1.test RULE=>custom("me")
FromOrTo:    .*@domain.*      RULE=>custom("domain-any")
FromOrTo:    .*@domain-2.test RULE=>custom("domain-2")
```
You see where I want to go. I now have the following resultset `[custom("domain-any"), custom("domain-any"), custom("domain-any"), custom("domain-2"), custom("domain-2")]`. In fact this generate the bug as per this PR, but the result is (IMO) unexpected.

### The Code

By simplifying `Config.pm` to minimum pseudo-code,  in `sub Value` we find:

```perl

if ($category =~ /first/i) {
    foreach $rule (@rulelist) {
        $result = FirstMatchValue( split $rule );
        return $result unless $result eq "CoNfIgFoUnDnOtHiNg";
    }
    return $Defaults{$name};

} else { # If all-matches
    my @results;
    foreach $rule (@{$rulelist}) {
        $result = AllMatchesValue( split $rule );
        next if $result eq "CoNfIgFoUnDnOtHiNg";
        push @results, $result;
    }

    # Return the results if there were any, else the defaults
    return join(",", @results) if @results and $name eq 'saactions';
    return join(" ", @results) if @results;
    return $Defaults{$name};
}
```
So  in case of first-match rule, the first configuration found (i.e. the first ruleset matching for whatever rule you defined) is returned. In case of all-match all the results are collected in an array and then returned.

So far so good. The problem is `AllMatchesValue`: this function is a huge copy-paste-than-adapted version of `FirstMatchValue`, which return multiple time the **same** passed-in `$value` instead of returning it just once.

### Long Term Solution

Remove `AllMatchesValue` sub-routine and just use `FirstMatchValue`. The All/One ruleset is now consistently described as "all/first ruleset's value(s) for which at least one match is valid".

Drawbacks? For all boolean types I see no drawbacks at all, as a single or multiple `Yes` are the same. 

For the `[All,Other]` category, I checked quickly at the code and I see only speed improvements, as the configuration is not duplicated and then deduplicated on usage (e.g. option ArchiveMail, FilenameMatch).

I can do the testing and the PR if you approve with this changes.