### PR TITLE
Force CPAN MIME::Tools install

### DIFF
--- a/debian/install.sh
+++ b/debian/install.sh
@@ -394,7 +394,7 @@ fi
 # install these from array above in case one of the 
 # packages produce an error
 #
-#"curl wget tar binutils libc6-dev gcc make patch gzip unzip openssl perl perl-doc libdbd-mysql-perl libconvert-tnef-perl libdbd-sqlite3-perl libfilesys-df-perl libmailtools-perl libnet-cidr-perl libsys-syslog-perl libio-stringy-perl perl-modules libdbd-mysql-perl libencode-detect-perl unrar antiword libarchive-zip-perl libconfig-yaml-perl libole-storage-lite-perl libsys-sigaction-perl pyzor razor tnef libinline-perl libmail-imapclient-perl libtest-pod-coverage-perl libfile-sharedir-install-perl libmail-spf-perl libnetaddr-ip-perl libsys-hostname-long-perl libhtml-tokeparser-simple-perl libmail-dkim-perl libnet-ldap-perl libnet-dns-resolver-programmable-perl libnet-cidr-lite-perl libtest-manifest-perl libdata-dump-perl libbusiness-isbn-data-perl libbusiness-isbn-perl";
+#"curl wget tar binutils libc6-dev gcc make patch gzip unzip openssl perl perl-doc libdbd-mysql-perl libconvert-tnef-perl libdbd-sqlite3-perl libfilesys-df-perl libmailtools-perl libmime-tools-perl libnet-cidr-perl libsys-syslog-perl libio-stringy-perl perl-modules libdbd-mysql-perl libencode-detect-perl unrar antiword libarchive-zip-perl libconfig-yaml-perl libole-storage-lite-perl libsys-sigaction-perl pyzor razor tnef libinline-perl libmail-imapclient-perl libtest-pod-coverage-perl libfile-sharedir-install-perl libmail-spf-perl libnetaddr-ip-perl libsys-hostname-long-perl libhtml-tokeparser-simple-perl libmail-dkim-perl libnet-ldap-perl libnet-dns-resolver-programmable-perl libnet-cidr-lite-perl libtest-manifest-perl libdata-dump-perl libbusiness-isbn-data-perl libbusiness-isbn-perl";
 
 # the array of perl modules needed
 ARMOD=();
@@ -503,9 +503,6 @@ else
     CURL='/usr/bin/curl';
 fi
 
-# Remove potentially outdated MIME::Tools and install from CPAN
-dpkg -r --ignore-depends=libmime-tools-perl libmime-tools-perl >/dev/null 2>&1
-
 # create the cpan config if there isn't one and the user
 # elected to use CPAN
 if [ $CPANOPTION == 1 ]; then
@@ -591,6 +588,10 @@ if [ ${CPANOPTION} == 1 ]; then
     done
 
 fi
+
+# Install MIME::Tools from CPAN even though rpm is present
+# Fixes outdated MIME::Tools causing MailScanner to crash
+perl -MCPAN -e "CPAN::Shell->force(qw(install MIME::Tools));"
 
 # check and notify of any missing modules
 ARMODALL=("${ARMOD[@]}" "${MODSA}" "${ARMODAFTERSA[@]}")

--- a/rhel/install.sh
+++ b/rhel/install.sh
@@ -688,7 +688,7 @@ BASEPACKAGES="binutils gcc glibc-devel libaio make man-pages man-pages-overrides
 # package is not available for their distro release it
 # will be ignored during the install.
 #
-MOREPACKAGES="perl-Archive-Tar perl-Archive-Zip perl-Compress-Raw-Zlib perl-Compress-Zlib perl-Convert-BinHex perl-Convert-TNEF perl-CPAN perl-Data-Dump perl-DBD-SQLite perl-DBI perl-Digest-HMAC perl-Digest-SHA1 perl-Env perl-ExtUtils-MakeMaker perl-File-ShareDir-Install perl-File-Temp perl-Filesys-Df perl-Getopt-Long perl-IO-String perl-IO-stringy perl-HTML-Parser perl-HTML-Tagset perl-Inline perl-IO-Zlib perl-Mail-DKIM perl-Mail-IMAPClient perl-Mail-SPF perl-MailTools perl-Net-CIDR perl-Net-DNS perl-Net-DNS-Resolver-Programmable perl-Net-IP perl-OLE-Storage_Lite perl-Pod-Escapes perl-Pod-Simple perl-Scalar-List-Utils perl-Storable perl-Pod-Escapes perl-Pod-Simple perl-Razor-Agent perl-Sys-Hostname-Long perl-Sys-SigAction perl-Test-Manifest perl-Test-Pod perl-Time-HiRes perl-TimeDate perl-URI perl-YAML pyzor re2c unrar tnef perl-Encode-Detect perl-LDAP perl-IO-Compress-Bzip2 p7zip p7zip-plugins";
+MOREPACKAGES="perl-Archive-Tar perl-Archive-Zip perl-Compress-Raw-Zlib perl-Compress-Zlib perl-Convert-BinHex perl-CPAN perl-Data-Dump perl-DBD-SQLite perl-DBI perl-Digest-HMAC perl-Digest-SHA1 perl-Env perl-ExtUtils-MakeMaker perl-File-ShareDir-Install perl-File-Temp perl-Filesys-Df perl-Getopt-Long perl-IO-String perl-IO-stringy perl-HTML-Parser perl-HTML-Tagset perl-Inline perl-IO-Zlib perl-Mail-DKIM perl-Mail-IMAPClient perl-Mail-SPF perl-MailTools perl-Net-CIDR perl-Net-DNS perl-Net-DNS-Resolver-Programmable perl-MIME-tools perl-Convert-TNEF perl-Net-IP perl-OLE-Storage_Lite perl-Pod-Escapes perl-Pod-Simple perl-Scalar-List-Utils perl-Storable perl-Pod-Escapes perl-Pod-Simple perl-Razor-Agent perl-Sys-Hostname-Long perl-Sys-SigAction perl-Test-Manifest perl-Test-Pod perl-Time-HiRes perl-TimeDate perl-URI perl-YAML pyzor re2c unrar tnef perl-Encode-Detect perl-LDAP perl-IO-Compress-Bzip2 p7zip p7zip-plugins";
 
 # the array of perl modules needed
 ARMOD=();
@@ -1044,18 +1044,13 @@ PMODWAIT=0
 # using this trick
 for i in "${ARMOD[@]}"
 do
-    if [ $i != "MIME::Tools" ]; then
-      perldoc -l $i >/dev/null 2>&1
-      if [ $? != 0 ]; then
-          echo "$i is missing. Trying to install via Yum ..."; echo;
-          THING="perl($i)";
-          $YUM -y install $THING
-      fi
+    perldoc -l $i >/dev/null 2>&1
+    if [ $? != 0 ]; then
+        echo "$i is missing. Trying to install via Yum ..."; echo;
+        THING="perl($i)";
+        $YUM -y install $THING
     fi
 done
-
-# Remove potentially outdated stock MIME::Tools that may be installed and let CPAN handle it instead
-$RPM -e --nodeps perl-MIME-tools >/dev/null 2>&1
 
 # CPAN automation invoked?
 if [ -z "${arg_installCPAN+x}" ]; then
@@ -1096,6 +1091,10 @@ do
         echo "$i => OK";
     fi
 done
+
+# Install MIME::Tools from CPAN even though rpm is present
+# Fixes outdated MIME::Tools causing MailScanner to crash
+perl -MCPAN -e "CPAN::Shell->force(qw(install MIME::Tools));"
 
 # will pause if a perl module was missing
 timewait $PMODWAIT

--- a/suse/install.sh
+++ b/suse/install.sh
@@ -389,7 +389,7 @@ BASEPACKAGES="binutils gcc glibc-devel libaio1 make man-pages patch rpm tar time
 # Packages available in the suse base 13.2. If the user elects not to use EPEL or if the 
 # package is not available for their distro release it will be ignored during the install.
 #
-MOREPACKAGES="perl-Archive-Zip perl-Convert-BinHex perl-Convert-TNEF perl-DBD-SQLite perl-DBI perl-Digest-HMAC perl-Digest-SHA1 perl-ExtUtils-MakeMaker perl-File-ShareDir-Install perl-File-Temp perl-Filesys-Df perl-Getopt-Long-Descriptive perl-IO-stringy perl-HTML-Parser perl-HTML-Tagset perl-Inline perl-Mail-DKIM perl-Mail-SPF perl-MailTools perl-Net-CIDR-Set perl-Net-DNS perl-Net-IP perl-OLE-Storage_Lite perl-Scalar-List-Utils perl-razor-agents perl-Sys-Hostname-Long perl-Sys-SigAction perl-Test-Pod perl-TimeDate perl-URI re2c perl-Encode-Detect perl-LDAP perl-IO-Compress-Bzip2 p7zip";
+MOREPACKAGES="perl-Archive-Zip perl-Convert-BinHex perl-Convert-TNEF perl-DBD-SQLite perl-DBI perl-MIME-tools perl-Digest-HMAC perl-Digest-SHA1 perl-ExtUtils-MakeMaker perl-File-ShareDir-Install perl-File-Temp perl-Filesys-Df perl-Getopt-Long-Descriptive perl-IO-stringy perl-HTML-Parser perl-HTML-Tagset perl-Inline perl-Mail-DKIM perl-Mail-SPF perl-MailTools perl-Net-CIDR-Set perl-Net-DNS perl-Net-IP perl-OLE-Storage_Lite perl-Scalar-List-Utils perl-razor-agents perl-Sys-Hostname-Long perl-Sys-SigAction perl-Test-Pod perl-TimeDate perl-URI re2c perl-Encode-Detect perl-LDAP perl-IO-Compress-Bzip2 p7zip";
 
 # the array of perl modules needed
 ARMOD=();
@@ -544,18 +544,13 @@ PMODWAIT=0
 # using this trick
 for i in "${ARMOD[@]}"
 do
-    if [ $i != "MIME::Tools" ]; then
-      perldoc -l $i >/dev/null 2>&1
-      if [ $? != 0 ]; then
-          echo "$i is missing. Trying to install via Zypper ..."; echo;
-          THING="perl($i)";
-          $ZYPPER --non-interactive --ignore-unknown install $THING
-      fi
+    perldoc -l $i >/dev/null 2>&1
+    if [ $? != 0 ]; then
+        echo "$i is missing. Trying to install via Zypper ..."; echo;
+        THING="perl($i)";
+        $ZYPPER --non-interactive --ignore-unknown install $THING
     fi
 done
-
-# Remove potentially outdated perl-MIME-Tools, if present, and update from CPAN instead
-$RPM -e --nodeps perl-MIME-Tools > /dev/null 2>&1
 
 # CPAN automation invoked?
 if [ -z "${arg_installCPAN+x}" ]; then
@@ -595,6 +590,10 @@ do
         echo "$i => OK";
     fi
 done
+
+# Install MIME::Tools from CPAN even though rpm is present
+# Fixes outdated MIME::Tools causing MailScanner to crash
+perl -MCPAN -e "CPAN::Shell->force(qw(install MIME::Tools));"
 
 # will pause if a perl module was missing
 timewait $PMODWAIT


### PR DESCRIPTION
Revert changes to package manager and leave MIME::Tools alone
Install CPAN version locally instead
Resolves dependency warnings from package managers