### PR TITLE
Postfix: correctly remove all recpients in DeleteRecipients

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/Postfix.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Postfix.pm
@@ -1361,7 +1361,7 @@ sub new {
       # Thanks to Holger Gebhard for this.
       #BUGGY: next unless $message->{metadata}[$linenum] =~ /^[ARO].+@(?:\w|-|\.)+\.\w{2,})/;
       #next unless $message->{metadata}[$linenum] =~ /^[ARO]/;
-      next unless $message->{metadata}[$linenum] =~ /^[ARO].+@(?:\w|-|\.)+\.\w{2,}/;
+      next unless $message->{metadata}[$linenum] =~ /^[ARO].+\@[a-zA-Z0-9\-.]+/;
       # Have found the right line
       #print STDERR "Deleting recip " . $message->{metadata}[$linenum] . "\n";
       splice(@{$message->{metadata}}, $linenum, 1);


### PR DESCRIPTION
There is a bug in handling of destination addresses in Postfix.pm. This is actually a regression introduced after an [old commit by Holger Gebhard](http://lists.mailscanner.info/pipermail/mailscanner/2006-August/064654.html).

In the beginning, `DeleteRecipients`  removed all addresses in Postfix sections R (recipients) and O (original recipients); with this commit 'A' (don't know the exact meaning in Postfix) were added, as well as some validation.

The validation is `/^[ARO].+@(?:\w|-|\.)+\.\w{2,}/`, which requires an `@`  (and this should be fine) but force syntax on hostnames, and this is bad.

My use case is this: I have a message from "user@hostname" which is analyzed and trigger action forward, but the address is not removed (due to the bug) and the forward address becomes a "CC".

The less stricter regexp `/^[ARO].+\@[a-zA-Z0-9\-.]+/` should be enough, but you may also consider the old (and probably good) expression `/^[ARO].*/`
