### PR TITLE
Clear recipient array during loop

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/MSMail.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/MSMail.pm
@@ -887,6 +887,9 @@ sub new {
       $queuehandle = new FileHandle();
 
       foreach $file (@Files) {
+
+          undef(@recipient);
+
           my $filename = $file;
           my $file = $queuedirname . '/' . $file;
           # Open file


### PR DESCRIPTION
Fix reuse of recipient array variable in KickMessage subroutine