### PR TITLE
Allow scan 7z archives if 'Find Archives By Content = no'

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/Message.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Message.pm
@@ -2907,7 +2907,7 @@ sub ExplodePartAndArchives {
                   $failisokay;
       #print STDERR "Found a zip or rar file\n" ;
       $file->close, next unless MailScanner::Config::Value('findarchivesbycontent', $this) ||
-                  $part =~ /\.(tar\.g?z|taz|tgz|tz|gz|zip|exe|rar|uu|uue|doc|docx|xls|xlsx|ppt|pptx|dot|dotx|xlt|xltx|pps|ppsx)$/i;
+                  $part =~ /\.(tar\.g?z|taz|tgz|tz|gz|zip|7z|exe|rar|uu|uue|doc|docx|xls|xlsx|ppt|pptx|dot|dotx|xlt|xltx|pps|ppsx)$/i;
       $foundnewfiles = 1;
       #print STDERR "Unpacking $part at level $level\n";
 


### PR DESCRIPTION
Hi,
The patch allows to scan 7zip archives by their extension if the option `Find Archives By Content` is set to `no` in the `Mailscanner.conf` file.
Thanks!
