### PR TITLE
Scan silent viruses also for spam option

### DIFF
--- a/common/etc/MailScanner/MailScanner.conf
+++ b/common/etc/MailScanner/MailScanner.conf
@@ -803,6 +803,32 @@ Silent Viruses = HTML-IFrame All-Viruses
 # This can also be the filename of a ruleset.
 Still Deliver Silent Viruses = no
 
+# Do you want to still scan the message for spam?
+# Setting this to yes will allow a message with a 
+# silent virus to proceed with spam checks and not be deleted immediately.
+# Silent viruses will be replaced with a warning message by default.
+#
+# This can be a filename of a ruleset.
+Still Scan Silent Viruses = no
+
+# If Still Deliver Silent Viruses is yes, do you want to deliver the
+# message unmodified?
+#
+# Warning: This is dangerous and should only be used if the
+# silent viruses you are targeting are safe.
+# Even so, a message could still have other viruses that could
+# come through with this setting enabled on the message payload.
+#
+# MailScanner versions <= to 5.1.3-2 actually did this by default
+# when Still Deliver Silent Viruses was set to yes. This setting exists
+# to remove this behavior by default in 5.1.4 onward.
+#
+# The subject line will still be modified if configured to do so for
+# virus infected messages, which is consistent with the old behavior.
+#
+# This can be a filename of a ruleset.
+Still Deliver Silent Viruses Unmodified = no
+
 # Strings listed here will be searched for in the output of the virus scanners.
 # It works to achieve the opposite effect of the "Silent Viruses" listed above.
 # If a string here is found in the output of the virus scanners, then the

--- a/common/usr/share/MailScanner/perl/MailScanner/ConfigDefs.pl
+++ b/common/usr/share/MailScanner/perl/MailScanner/ConfigDefs.pl
@@ -96,6 +96,8 @@ deletedsizemessage		= deletedsizemessagereport
 deletedvirusmessage		= deletedvirusmessagereport
 deliverdisinfected		= deliverdisinfectedfiles
 deliversilent			= stilldeliversilentviruses
+scansilent			= stillscansilentviruses
+deliversilentunmodified		= stilldeliversilentvirusesunmodified
 dirtyheader			= infectedheadervalue
 disarmmodifysubject		= disarmedmodifysubject
 disarmsubjecttext		= disarmedsubjecttext
@@ -455,6 +457,8 @@ CheckSAIfOnSpamList	1	no	0	yes	1
 ContentModifySubject	start	no	0	yes	1	start	start	end	end
 DeliverDisinfected	0	no	0	yes	1
 DeliverSilent		0	no	0	yes	1
+ScanSilent		0	no	0	yes	1
+DeliverSilentUnmodified	0	no	0	yes	1
 deliverunparsabletnef	0	no	0	yes	1
 deliverymethod		batch	batch	batch	queue	queue
 DisarmModifySubject	start	no	0	yes	1	start	start	end	end


### PR DESCRIPTION
Issue #384 Enhancement and fix for Deliver Silent Viruses

Adds two new settings and their defaults:

```
Still Scan Silent Viruses = no
Still Deliver Silent Viruses Unmodified = no
```

Note that this change impacts users who are using Deliver Silent Viruses = yes and changes the default behavior of this setting.  Deliver Silent Viruses is supposed to clean messages as described in MailScanner.conf but does not.  This PR fixes that behavior to align with the description.  

Users that need the old functionality should set the following after reading the warning in MailScanner.conf:

```
Still Deliver Silent Viruses Unmodified = yes
```

Users that want silent viruses to also be checked for spam should set:

```
Still Scan Silent Viruses = yes
```

