### PR TITLE
Fix skip unzipping of the Microsoft documents (.xlsx, .pptx, .docx)

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/Message.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Message.pm
@@ -2925,9 +2925,14 @@ sub ExplodePartAndArchives {
       # Is it a zip file, in which case unpack the zip
       $ziperror = "";
       #print STDERR "About to unpackzip $part\n";
-      $ziperror = $this->UnpackZip($part, $explodeinto, $allowpasswords,
+      # Skip unzip processing when "Unpack Microsoft Documents = no" and
+      # the `file -b' result is "Microsoft Word|Excel|PowerPoint 2007+".
+      if (MailScanner::Config::Value('unpackole', $this) ||
+          $memb !~ /^Microsoft (Word|Excel|PowerPoint) 2007\+/) {
+        $ziperror = $this->UnpackZip($part, $explodeinto, $allowpasswords,
                                    $insistpasswords,
                                    $onlycheckencryption, $create0files);
+      }
       #MailScanner::Log::WarnLog("UnpackZip (%s) file (%s)", $ziperror, $part);
       #print STDERR "* * * * * * * Unpackzip $part returned $ziperror\n";
       # If unpacking as a zip failed, try it as a rar


### PR DESCRIPTION
This patch fix the issue for `.xlsx`, `.pptx`, `.docx` files (mostly it was created for `.xlsx` files) and the error like `MailScanner: No programs allowed (4workbook.bin)`. Example thread https://forum.efa-project.org/viewtopic.php?t=2982

MailScanner.conf comments say next:
```
# Do you want to unpack Microsoft "OLE" documents, such as *.doc, *.xls
# and *.ppt documents? This will extract any files which have been hidden
# by being embedded in these documents.
# There are one or two minor bugs in the third-party code that does the
# processing of these files, so it can cause MailScanner to hang in very
# rare cases.
# ClamAV has its own OLE unpacking code, so you can safely switch this off
# if you just rely on ClamAV for your virus-scanning. Note that this will,
# however, disabled all filename and filetype checking of embedded files.
# This can also be the filename of a ruleset.
Unpack Microsoft Documents = yes
```

Well, currently "_ClamAV has its own OLE unpacking code, so you can safely switch this off if you just rely on ClamAV for your virus-scanning._" is not working. In other words, if I set `Unpack Microsoft Documents = no` then I still getting the error "No programs allowed".

This patch correctly handles this situation. Perhaps, I am wrong about the implementation of the patch, correct me if so.

Thank you!
