### PR TITLE
Override Filetypes

### DIFF
--- a/common/etc/MailScanner/MailScanner.conf
+++ b/common/etc/MailScanner/MailScanner.conf
@@ -1312,7 +1312,7 @@ Deny Filenames =
 Filename Rules = %etc-dir%/filename.rules.conf
 
 # Allow filename rules to take precedence over filetype rules.
-# If this setting is yes, filenames that are allowed will always
+# If this setting is yes, filenames that are allowed will always be
 # allowed and the filetype check will be skipped for the file.
 # If this is no (default), files must pass both filename and filetype
 # checks. This applies to both file attachments and archive contents.

--- a/common/etc/MailScanner/MailScanner.conf
+++ b/common/etc/MailScanner/MailScanner.conf
@@ -1311,6 +1311,14 @@ Deny Filenames =
 # a ruleset or not!
 Filename Rules = %etc-dir%/filename.rules.conf
 
+# Allow filename rules to take precedence over filetype rules.
+# If this setting is yes, filenames that are allowed will always
+# allowed and the filetype check will be skipped for the file.
+# If this is no (default), files must pass both filename and filetype
+# checks. This applies to both file attachments and archive contents.
+# This can also be a filename of a ruleset.
+Override Filetypes = no
+
 # To simplify web-based configuration systems, there are now two extra
 # settings here. They are both intended for use with normal rulesets
 # that you would expect to find in %rules-dir%. The first gives a list

--- a/common/usr/share/MailScanner/perl/MailScanner/ConfigDefs.pl
+++ b/common/usr/share/MailScanner/perl/MailScanner/ConfigDefs.pl
@@ -692,6 +692,7 @@ UseSpamAssassin		1	no	0	yes	1
 UseWatermarking		1	no	0	yes	1
 VirusScan		1	no	0	yes	1
 ZipAttachments		0	no	0	yes	1
+OverrideFiletypes		0	no	0	yes	1
 
 [All,File]
 #FilenameRules		/etc/MailScanner/filename.rules.conf

--- a/common/usr/share/MailScanner/perl/MailScanner/SweepOther.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/SweepOther.pm
@@ -261,6 +261,9 @@ sub ScanBatch {
           #print STDERR "Allow exists\n";
           if ($attach =~ /$megaallow/is || $notypesafename =~ /$megaallow/is) {
             $MatchFound = 1;
+            if (MailScanner::Config::Value('overridefiletypes', $message) =~ /1/) {
+              $message->{override}->{$safename} = 1;
+            }
             #print STDERR "Allowing filename $id\t$notypesafename\n";
             MailScanner::Log::InfoLog("Filename Checks: Allowing %s %s",
                                       $id, $notypesafename)
@@ -391,6 +394,9 @@ sub ScanBatch {
             MailScanner::Log::InfoLog("Filename Checks: Allowing %s %s",
                                       $id, $notypesafename)
               if $LogNames;
+            if (MailScanner::Config::Value('overridefiletypes', $message) =~ /1/) {
+              $message->{override}->{$safename} = 1;
+            }
           }
         }
         MailScanner::Log::InfoLog("Filename Checks: Allowing %s %s " .
@@ -688,6 +694,11 @@ sub CheckFileTypesRules {
       $attach = $message->{safefile2file}{$safename} || $tnefname;
       next if $attach eq "" && $safename eq "";
 
+      if (MailScanner::Config::Value('overridefiletypes', $message) =~ /1/ && $message->{override}->{$safename} == 1) {
+        MailScanner::Log::InfoLog("Filetype Checks: Overriding checks for %s %s", $id, $safename);
+        next;
+      }
+
       if (MailScanner::Config::Value('aignoredatexecutable', $message) =~ /1/ && $attach =~ /\.dat$/ && $TypeIndicator =~ /$ArchivesAre/) {
         ## Will prevent to quarantine email if MS Office/Corel
         ## attachment contains a .dat file
@@ -897,6 +908,11 @@ sub CheckFileTypesRules {
     while(($safename, $type) = each %$attachtypes) {
       $attach = $message->{safefile2file}{$safename} || $tnefname;
       next if $attach eq "" && $safename eq "";
+
+      if (MailScanner::Config::Value('overridefiletypes', $message) =~ /1/ && $message->{override}->{$safename} == 1) {
+        MailScanner::Log::InfoLog("Filetype Checks: Overriding checks for %s %s", $id, $safename);
+        next;
+      }
 
       if (MailScanner::Config::Value('aignoredatexecutable', $message) =~ /1/ && $attach =~ /\.dat$/ && $TypeIndicator =~ /$ArchivesAre/) {
         ## Will prevent to quarantine email if MS Office/Corel


### PR DESCRIPTION
Allows explicit filename rules to override filetype rules

Fixes #592
Fixes #554