### PR TITLE
correct empty line in received-header

### DIFF
--- a/common/usr/sbin/MSMilter
+++ b/common/usr/sbin/MSMilter
@@ -233,15 +233,13 @@ sub envrcpt_callback
                 MailScanner::Log::DebugLog("envrcpt_callback: ssl/tls detected");
         }
         if (!defined($symbols->{'H'}->{'{cert_subject}'})) {
-            ${$message_ref} .= "\t(no client certificate requested)";
+            ${$message_ref} .= "\t(no client certificate requested)\n";
             MailScanner::Log::DebugLog("envrcpt_callback: no client certificate requested");
         }
         if (defined($symbols->{'M'}->{'{auth_type}'}) && defined($symbols->{'M'}->{'{auth_authen}'})) {
             ${$message_ref} .= "\t(Authenticated sender)\n";
             MailScanner::Log::DebugLog("envrcpt_callback: Authenticated sender: " . $symbols->{'M'}->{'{auth_authen}'});
             ${$message_ref} = "A<sasl_method=" . $symbols->{'M'}->{'{auth_type}'} . ">\n" . ${$message_ref};
-        } else {
-            ${$message_ref} .= "\n";
         }
         ${$message_ref} .= "\tby " . hostname . ' (MailScanner Milter) with SMTP id ';
     }


### PR DESCRIPTION
when the 'if' statements at lines 235 and 239 were both false, nothing more was added except another '\n' at line 244.

this empty line then caused Mailscanner to truncate all following header lines.

see issue #618 
thanks to @msapiro 
