### PR TITLE
Skip signing calendar mimetypes

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/Message.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/Message.pm
@@ -5010,6 +5010,7 @@ sub SignExternalMessage {
 
   my $MimeType = $top->head->mime_type if $top->head;
   return 0 unless $MimeType =~ m{text/}i; # Won't sign non-text message.
+  return 0 if $MimeType =~ /text\/calendar/i; # Don't sign calendars
   # Won't sign attachments.
   return 0 if $top->head->mime_attr('content-disposition') =~ /attachment/i;
 


### PR DESCRIPTION
For when a calendar "attachment" isn't really identified as an attachment and is a text mime part