### PR TITLE
de/languages.conf umlaut correction

### DIFF
--- a/common/usr/share/MailScanner/reports/de/languages.conf
+++ b/common/usr/share/MailScanner/reports/de/languages.conf
@@ -79,7 +79,7 @@ ArchiveTooDeep = Nachricht enthielt zu viele ineinander verschachtelte Archiv-Da
 # Used in Postmaster notices
 NoticeVirusInfected = Virus erkannt
 NoticeFilenameInfected = Unerlaubten Dateinamen gefunden
-NoticeOtherInfected = Sonstige gef&ouml;hrliche Inhalte gefunden
+NoticeOtherInfected = Sonstige gef&auml;hrliche Inhalte gefunden
 NoticePasswordProtected = Passwort-gesch&uuml;tzte Archiv-Datei gefunden
 NoticeNonPasswordProtected = Non-password-protected Archive Detected
 # NoticePrefix = The following e-mails were found to have
@@ -89,7 +89,7 @@ NoticePrefix = Die folgenden E-Mails besassen
 PossibleFraudStart = <font color="red"><b>MailScanner hat einen m&ouml;glichen T&auml;uschungsversuch durch
 PossibleFraudEnd = festgestellt.</b></font>
 # NumericLinkWarning = <font color="red"><b>MailScanner Warnung: numerical links are often malicious:</b></font>
-NumericLinkWarning = <font color="red"><b>MailScanner Warnung: nummerische Links sind oftmals  arglistig:</b></font>
+NumericLinkWarning = <font color="red"><b>MailScanner Warnung: nummerische Links sind oftmals arglistig:</b></font>
 # Used in "From:" header of many reports
 PostmasterName = MailScanner
 # GSDisabled = Custom Spam Scanner disabled due to repeated failures


### PR DESCRIPTION
Hello,

It should be "gefährliche" not "geföhrliche".
Question: must this text be HTML encoded? This string doesn't seem to be transcoded before being used as the email subject.

Also removing a double space.
File end change was made by the Github editor. Sorry.

Regards,
_Dirk_
