### PR TITLE
Allow more structured data script tag types

### DIFF
--- a/common/usr/share/MailScanner/perl/MailScanner/SweepContent.pm
+++ b/common/usr/share/MailScanner/perl/MailScanner/SweepContent.pm
@@ -519,7 +519,7 @@ sub SearchHTMLBody {
       # Find the script tag start
       # $scriptfound = 1 if /\<script/i;
       $script_check = 1 if /\<script/i;
-      $scriptfound = 1 if $script_check && !/application\/ld\+json/i;
+      $scriptfound = 1 if $script_check && !/\btype="application\/(?:[a-z-]+\+json|json\+[a-z-]+)"/i;
 
       # Find the img tag start
       $webbugfound = 1 if /\<img/i;


### PR DESCRIPTION
To fix #46 a simple logic was applied to `SearchHTMLBody` to only allow script tags if they contained the string `application/ld+json` but there are other structured data scripts that are not harmful.

One such script is `application/json+trustpilot` (see <https://help.trustpilot.com/s/article/Add-a-structured-data-snippet-for-Automatic-Feedback-Service?language=en_US>)

I modified the logic to allow a more generic type pattern of `application/*+json` and `application/json+*`. The code also looks for the string `type="..."` as this prevents scripts like `<script type="application/javascript" whatever="application/ld+json">` to bypass the filter.

IMHO this would be better implemented as a configurable pattern, but as a simple alternative this should be flexible enough for now.

Another alternative would be to only block script tags where the `type` attribute is either missing or one of `application/javascript` or `text/javascript` since these are in theory the only potentially dangerous types. This would work better against a script written like this: `<script type="application/javascript" type="application/ld+json">` which would still be included in the email.


