### PR TITLE
Fix handle --installCPAN CLI argument correctly for CPANOPTION

### DIFF
--- a/rhel/usr/sbin/ms-configure
+++ b/rhel/usr/sbin/ms-configure
@@ -601,6 +601,8 @@ if [ -z "${arg_installCPAN+x}" ]; then
         # user does not want to use CPAN
         CPANOPTION=0
     fi
+else
+    CPANOPTION=${arg_installCPAN}
 fi
 
 # ask about setting permissive mode for SeLinux


### PR DESCRIPTION
Previously, the script did not properly set CPANOPTION when the --installCPAN argument was provided via the command line. This change ensures that CPANOPTION is set based on the CLI parameter.